### PR TITLE
The Cloud Queues provider for Rackspace UK.

### DIFF
--- a/rackspace-cloudqueues-uk/README.md
+++ b/rackspace-cloudqueues-uk/README.md
@@ -1,0 +1,7 @@
+Rackspace Cloud Queues US
+=========================
+
+The Rackspace deployment of OpenStack Marconi, the Queues as a Service.
+
+Production ready?
+No

--- a/rackspace-cloudqueues-uk/pom.xml
+++ b/rackspace-cloudqueues-uk/pom.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.jclouds</groupId>
+    <artifactId>jclouds-project</artifactId>
+    <version>1.7.0-SNAPSHOT</version>
+  </parent>
+  
+  <!-- TODO: when out of labs, switch to org.jclouds.provider; update dependencies when Marconi is moved to jclouds -->
+  
+  <groupId>org.apache.jclouds.labs</groupId>
+  <artifactId>rackspace-cloudqueues-uk</artifactId>
+  <version>1.7.0-SNAPSHOT</version>
+  <name>jclouds Rackspace Cloud Queues UK provider</name>
+  <description>OpenStack Marconi implementation targeted to Rackspace Cloud Queues UK</description>
+  <packaging>bundle</packaging>
+
+  <properties>
+    <test.rackspace-cloudqueues-uk.endpoint>https://lon.identity.api.rackspacecloud.com/v2.0/</test.rackspace-cloudqueues-uk.endpoint>
+    <test.rackspace-cloudqueues-uk.api-version>1</test.rackspace-cloudqueues-uk.api-version>
+    <test.rackspace-cloudqueues-uk.build-version />
+    <test.rackspace-cloudqueues-uk.identity>${test.rackspace-uk.identity}</test.rackspace-cloudqueues-uk.identity>
+    <test.rackspace-cloudqueues-uk.credential>${test.rackspace-uk.credential}</test.rackspace-cloudqueues-uk.credential>
+    <test.rackspace-cloudqueues-uk.template />
+    <jclouds.osgi.export>org.jclouds.rackspace.cloudqueues.uk*;version="${project.version}"</jclouds.osgi.export>
+    <jclouds.osgi.import>
+      org.jclouds.compute.internal;version="${project.version}",
+      org.jclouds.rest.internal;version="${project.version}",
+      org.jclouds*;version="${project.version}",
+      *
+    </jclouds.osgi.import>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>apache-snapshots</id>
+      <url>https://repository.apache.org/content/repositories/snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.jclouds</groupId>
+      <artifactId>jclouds-core</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.labs</groupId>
+      <artifactId>openstack-marconi</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.api</groupId>
+      <artifactId>openstack-keystone</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.api</groupId>
+      <artifactId>rackspace-cloudidentity</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds</groupId>
+      <artifactId>jclouds-core</artifactId>
+      <version>${project.parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.labs</groupId>
+      <artifactId>openstack-marconi</artifactId>
+      <version>${project.parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.api</groupId>
+      <artifactId>openstack-keystone</artifactId>
+      <version>${project.parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.api</groupId>
+      <artifactId>rackspace-cloudidentity</artifactId>
+      <version>${project.parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.driver</groupId>
+      <artifactId>jclouds-slf4j</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <profiles>
+    <profile>
+      <id>live</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>integration</id>
+                <phase>integration-test</phase>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <forkCount>5</forkCount>
+                  <reuseForks>true</reuseForks>
+                  <parallel>classes</parallel>
+                  <systemPropertyVariables>
+                    <test.rackspace-cloudqueues-uk.endpoint>${test.rackspace-cloudqueues-uk.endpoint}</test.rackspace-cloudqueues-uk.endpoint>
+                    <test.rackspace-cloudqueues-uk.api-version>${test.rackspace-cloudqueues-uk.api-version}</test.rackspace-cloudqueues-uk.api-version>
+                    <test.rackspace-cloudqueues-uk.build-version>${test.rackspace-cloudqueues-uk.build-version}</test.rackspace-cloudqueues-uk.build-version>
+                    <test.rackspace-cloudqueues-uk.identity>${test.rackspace-cloudqueues-uk.identity}</test.rackspace-cloudqueues-uk.identity>
+                    <test.rackspace-cloudqueues-uk.credential>${test.rackspace-cloudqueues-uk.credential}</test.rackspace-cloudqueues-uk.credential>
+                    <test.rackspace-cloudqueues-uk.template>${test.rackspace-cloudqueues-uk.template}</test.rackspace-cloudqueues-uk.template>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+</project>

--- a/rackspace-cloudqueues-uk/src/main/java/org/jclouds/rackspace/cloudqueues/uk/CloudQueuesUKProviderMetadata.java
+++ b/rackspace-cloudqueues-uk/src/main/java/org/jclouds/rackspace/cloudqueues/uk/CloudQueuesUKProviderMetadata.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudqueues.uk;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Module;
+import org.jclouds.openstack.keystone.v2_0.config.KeystoneAuthenticationModule.ZoneModule;
+import org.jclouds.openstack.marconi.v1.MarconiApiMetadata;
+import org.jclouds.openstack.marconi.v1.config.MarconiHttpApiModule;
+import org.jclouds.openstack.marconi.v1.config.MarconiTypeAdapters;
+import org.jclouds.providers.ProviderMetadata;
+import org.jclouds.providers.internal.BaseProviderMetadata;
+import org.jclouds.rackspace.cloudidentity.v2_0.ServiceType;
+import org.jclouds.rackspace.cloudidentity.v2_0.config.CloudIdentityAuthenticationApiModule;
+import org.jclouds.rackspace.cloudidentity.v2_0.config.CloudIdentityAuthenticationModule;
+import org.jclouds.rackspace.cloudidentity.v2_0.config.CloudIdentityCredentialTypes;
+
+import java.net.URI;
+import java.util.Properties;
+
+import static org.jclouds.location.reference.LocationConstants.ISO3166_CODES;
+import static org.jclouds.location.reference.LocationConstants.PROPERTY_ZONE;
+import static org.jclouds.location.reference.LocationConstants.PROPERTY_ZONES;
+import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.CREDENTIAL_TYPE;
+import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.SERVICE_TYPE;
+
+/**
+ * Implementation of Rackspace Cloud Queues.
+ * 
+ * @author Everett Toews
+ */
+public class CloudQueuesUKProviderMetadata extends BaseProviderMetadata {
+
+   public static Builder builder() {
+      return new Builder();
+   }
+
+   @Override
+   public Builder toBuilder() {
+      return builder().fromProviderMetadata(this);
+   }
+
+   public CloudQueuesUKProviderMetadata() {
+      super(builder());
+   }
+
+   public CloudQueuesUKProviderMetadata(Builder builder) {
+      super(builder);
+   }
+
+   public static Properties defaultProperties() {
+      Properties properties = new Properties();
+      properties.setProperty(CREDENTIAL_TYPE, CloudIdentityCredentialTypes.API_KEY_CREDENTIALS);
+      properties.setProperty(SERVICE_TYPE, ServiceType.QUEUES);
+      properties.setProperty(PROPERTY_ZONES, "LON");
+      properties.setProperty(PROPERTY_ZONE + ".LON." + ISO3166_CODES, "GB-SLG");
+
+      return properties;
+   }
+   
+   public static class Builder extends BaseProviderMetadata.Builder {
+
+      protected Builder(){
+         id("rackspace-cloudqueues-uk")
+         .name("Rackspace Cloud Queues UK")
+         .apiMetadata(new MarconiApiMetadata().toBuilder()
+               .identityName("${userName}")
+               .credentialName("${apiKey}")
+               .defaultEndpoint("https://lon.identity.api.rackspacecloud.com/v2.0/")
+               .endpointName("Rackspace Cloud Identity service URL ending in /v2.0/")
+               .documentation(URI.create("http://docs.rackspace.com/queues/api/v1.0/cq-devguide/content/overview.html"))
+               .defaultModules(ImmutableSet.<Class<? extends Module>>builder()
+                     .add(CloudIdentityAuthenticationApiModule.class)
+                     .add(CloudIdentityAuthenticationModule.class)
+                     .add(ZoneModule.class)
+                     .add(MarconiTypeAdapters.class)
+                     .add(MarconiHttpApiModule.class).build())
+               .build())
+         .homepage(URI.create("http://www.rackspace.com/cloud/queues/"))
+         .console(URI.create("https://mycloud.rackspace.co.uk"))
+         .linkedServices("rackspace-cloudservers-uk", "cloudfiles-uk")
+         .iso3166Codes("GB-SLG")
+         .endpoint("https://lon.identity.api.rackspacecloud.com/v2.0/")
+         .defaultProperties(CloudQueuesUKProviderMetadata.defaultProperties());
+      }
+
+      @Override
+      public CloudQueuesUKProviderMetadata build() {
+         return new CloudQueuesUKProviderMetadata(this);
+      }
+
+      @Override
+      public Builder fromProviderMetadata(ProviderMetadata in) {
+         super.fromProviderMetadata(in);
+         return this;
+      }
+   }
+}

--- a/rackspace-cloudqueues-uk/src/main/resources/META-INF/services/org.jclouds.providers.ProviderMetadata
+++ b/rackspace-cloudqueues-uk/src/main/resources/META-INF/services/org.jclouds.providers.ProviderMetadata
@@ -1,0 +1,1 @@
+org.jclouds.rackspace.cloudqueues.uk.CloudQueuesUKProviderMetadata

--- a/rackspace-cloudqueues-uk/src/test/java/org/jclouds/rackspace/cloudqueues/uk/CloudQueuesUKClaimApiLiveTest.java
+++ b/rackspace-cloudqueues-uk/src/test/java/org/jclouds/rackspace/cloudqueues/uk/CloudQueuesUKClaimApiLiveTest.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudqueues.uk;
+
+import org.jclouds.openstack.marconi.v1.features.ClaimApiLiveTest;
+import org.testng.annotations.Test;
+
+/**
+ * @author Everett Toews
+ */
+@Test(groups = "live", testName = "CloudQueuesUKClaimApiLiveTest")
+public class CloudQueuesUKClaimApiLiveTest extends ClaimApiLiveTest {
+   public CloudQueuesUKClaimApiLiveTest() {
+      provider = "rackspace-cloudqueues-uk";
+   }
+}

--- a/rackspace-cloudqueues-uk/src/test/java/org/jclouds/rackspace/cloudqueues/uk/CloudQueuesUKMessageApiLiveTest.java
+++ b/rackspace-cloudqueues-uk/src/test/java/org/jclouds/rackspace/cloudqueues/uk/CloudQueuesUKMessageApiLiveTest.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudqueues.uk;
+
+import org.jclouds.openstack.marconi.v1.features.MessageApiLiveTest;
+import org.testng.annotations.Test;
+
+/**
+ * @author Everett Toews
+ */
+@Test(groups = "live", testName = "CloudQueuesUKMessageApiLiveTest")
+public class CloudQueuesUKMessageApiLiveTest extends MessageApiLiveTest {
+   public CloudQueuesUKMessageApiLiveTest() {
+      provider = "rackspace-cloudqueues-uk";
+   }
+}

--- a/rackspace-cloudqueues-uk/src/test/java/org/jclouds/rackspace/cloudqueues/uk/CloudQueuesUKQueueApiLiveTest.java
+++ b/rackspace-cloudqueues-uk/src/test/java/org/jclouds/rackspace/cloudqueues/uk/CloudQueuesUKQueueApiLiveTest.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cloudqueues.uk;
+
+import org.jclouds.openstack.marconi.v1.features.QueueApiLiveTest;
+import org.testng.annotations.Test;
+
+/**
+ * @author Everett Toews
+ */
+@Test(groups = "live", testName = "CloudQueuesUKQueueApiLiveTest")
+public class CloudQueuesUKQueueApiLiveTest extends QueueApiLiveTest {
+   public CloudQueuesUKQueueApiLiveTest() {
+      provider = "rackspace-cloudqueues-uk";
+   }
+}

--- a/rackspace-cloudqueues-uk/src/test/resources/logback.xml
+++ b/rackspace-cloudqueues-uk/src/test/resources/logback.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration scan="false">
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>target/test-data/jclouds.log</file>
+
+        <encoder>
+            <Pattern>%d %-5p [%c] [%thread] %m%n</Pattern>
+        </encoder>
+    </appender>
+
+    <appender name="WIREFILE" class="ch.qos.logback.core.FileAppender">
+        <file>target/test-data/jclouds-wire.log</file>
+
+        <encoder>
+            <Pattern>%d %-5p [%c] [%thread] %m%n</Pattern>
+        </encoder>
+    </appender>
+
+    <appender name="BLOBSTOREFILE" class="ch.qos.logback.core.FileAppender">
+        <file>target/test-data/jclouds-blobstore.log</file>
+
+        <encoder>
+            <Pattern>%d %-5p [%c] [%thread] %m%n</Pattern>
+        </encoder>
+    </appender>
+
+    <root>
+        <level value="warn" />
+    </root>
+
+    <logger name="org.jclouds">
+        <level value="DEBUG" />
+        <appender-ref ref="FILE" />
+    </logger>
+
+    <logger name="jclouds.wire">
+        <level value="DEBUG" />
+        <appender-ref ref="WIREFILE" />
+    </logger>
+
+    <logger name="jclouds.headers">
+        <level value="DEBUG" />
+        <appender-ref ref="WIREFILE" />
+    </logger>
+
+    <logger name="jclouds.blobstore">
+        <level value="DEBUG" />
+        <appender-ref ref="BLOBSTOREFILE" />
+    </logger>
+
+</configuration>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/JCLOUDS-340

Can we get this in for 1.7.0?

To run live tests:

```
mvn -Plive -Dtest.rackspace-cloudqueues-uk.identity=[username] -Dtest.rackspace-cloudqueues-uk.credential=[apikey] clean install
```
