### PR TITLE
Added Cloud Files API/Providers to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ Although this is a "labs" repository, some of the providers and APIs here are pr
 | openstack-neutron | API | Yes |
 | openstack-swift | API | No |
 | rackspace-autoscale | API | No |
+| rackspace-cloudfiles | API | No |
 | rackspace-autoscale-us | Provider | No |
+| rackspace-cloudfiles-uk | Provider | No |
+| rackspace-cloudfiles-us | Provider | No |
 | rackspace-cloudqueues-us | Provider | No |
 
 License


### PR DESCRIPTION
The subject says it all!

This PR can be merged once the Rackspace Cloud Files API/US Provider [PR 79](https://github.com/jclouds/jclouds-labs-openstack/pull/79) and another dependent PR to include the Rackspace Cloud Files UK Provider are merged to master.

I will check back once that happens to move this along. Thx!
