### PR TITLE
Prefer OpenStack Regions

### DIFF
--- a/openstack-glance/src/main/java/org/jclouds/openstack/glance/functions/RegionToEndpointNegotiateVersion.java
+++ b/openstack-glance/src/main/java/org/jclouds/openstack/glance/functions/RegionToEndpointNegotiateVersion.java
@@ -21,8 +21,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
-import java.io.InputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
@@ -35,9 +35,9 @@ import javax.inject.Singleton;
 
 import org.jclouds.http.HttpRequest;
 import org.jclouds.json.Json;
-import org.jclouds.location.Zone;
-import org.jclouds.rest.annotations.ApiVersion;
+import org.jclouds.location.Region;
 import org.jclouds.rest.HttpClient;
+import org.jclouds.rest.annotations.ApiVersion;
 import org.jclouds.util.Strings2;
 
 import com.google.common.base.Function;
@@ -51,7 +51,7 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Iterables;
 
 @Singleton
-public class ZoneToEndpointNegotiateVersion implements Function<Object, URI> {
+public class RegionToEndpointNegotiateVersion implements Function<Object, URI> {
 
    public static final String VERSION_NEGOTIATION_HEADER = "Is-Version-Negotiation-Request";
 
@@ -70,14 +70,14 @@ public class ZoneToEndpointNegotiateVersion implements Function<Object, URI> {
       public List<Version> versions;
    }
 
-   private final Supplier<Map<String, Supplier<URI>>> zoneToEndpointSupplier;
+   private final Supplier<Map<String, Supplier<URI>>> regionToEndpointSupplier;
    private final String apiVersion;
    private final LoadingCache<URI, URI> endpointCache;
 
    @Inject
-   public ZoneToEndpointNegotiateVersion(@Zone Supplier<Map<String, Supplier<URI>>> zoneToEndpointSupplier,
+   public RegionToEndpointNegotiateVersion(@Region Supplier<Map<String, Supplier<URI>>> regionToEndpointSupplier,
          @ApiVersion String rawApiVersionString, final HttpClient client, final Json json) {
-      this.zoneToEndpointSupplier = checkNotNull(zoneToEndpointSupplier, "zoneToEndpointSupplier");
+      this.regionToEndpointSupplier = checkNotNull(regionToEndpointSupplier, "regionToEndpointSupplier");
       if (!rawApiVersionString.startsWith("v")) {
          this.apiVersion = "v" + rawApiVersionString;
       } else {
@@ -125,12 +125,12 @@ public class ZoneToEndpointNegotiateVersion implements Function<Object, URI> {
 
    @Override
    public URI apply(Object from) {
-      checkArgument(from instanceof String, "you must specify a zone, as a String argument");
-      Map<String, Supplier<URI>> zoneToEndpoint = zoneToEndpointSupplier.get();
-      checkState(!zoneToEndpoint.isEmpty(), "no zone name to endpoint mappings configured!");
-      checkArgument(zoneToEndpoint.containsKey(from),
-               "requested location %s, which is not in the configured locations: %s", from, zoneToEndpoint);
-      URI uri = zoneToEndpointSupplier.get().get(from).get();
+      checkArgument(from instanceof String, "you must specify a region, as a String argument");
+      Map<String, Supplier<URI>> regionToEndpoint = regionToEndpointSupplier.get();
+      checkState(!regionToEndpoint.isEmpty(), "no region name to endpoint mappings configured!");
+      checkArgument(regionToEndpoint.containsKey(from),
+               "requested location %s, which is not in the configured locations: %s", from, regionToEndpoint);
+      URI uri = regionToEndpointSupplier.get().get(from).get();
 
       try {
          return endpointCache.get(uri);

--- a/openstack-glance/src/main/java/org/jclouds/openstack/glance/v1_0/GlanceApi.java
+++ b/openstack-glance/src/main/java/org/jclouds/openstack/glance/v1_0/GlanceApi.java
@@ -20,8 +20,8 @@ import java.io.Closeable;
 import java.util.Set;
 
 import org.jclouds.javax.annotation.Nullable;
-import org.jclouds.location.Zone;
-import org.jclouds.openstack.glance.functions.ZoneToEndpointNegotiateVersion;
+import org.jclouds.location.Region;
+import org.jclouds.openstack.glance.functions.RegionToEndpointNegotiateVersion;
 import org.jclouds.openstack.glance.v1_0.features.ImageApi;
 import org.jclouds.rest.annotations.Delegate;
 import org.jclouds.rest.annotations.EndpointParam;
@@ -35,18 +35,18 @@ import com.google.inject.Provides;
  */
 public interface GlanceApi extends Closeable {
    /**
-    * Gets the configured zones.
+    * Gets the configured regions.
     *
-    * @return the zone codes currently configured
+    * @return the region codes currently configured
     */
    @Provides
-   @Zone
-   Set<String> getConfiguredZones();
+   @Region
+   Set<String> getConfiguredRegions();
 
    /**
     * Provides access to Image features.
     */
    @Delegate
-   ImageApi getImageApiForZone(@EndpointParam(parser = ZoneToEndpointNegotiateVersion.class) @Nullable String zone);
+   ImageApi getImageApi(@EndpointParam(parser = RegionToEndpointNegotiateVersion.class) @Nullable String region);
 
 }

--- a/openstack-glance/src/main/java/org/jclouds/openstack/glance/v1_0/GlanceApiMetadata.java
+++ b/openstack-glance/src/main/java/org/jclouds/openstack/glance/v1_0/GlanceApiMetadata.java
@@ -26,7 +26,7 @@ import org.jclouds.openstack.glance.v1_0.config.GlanceHttpApiModule;
 import org.jclouds.openstack.keystone.v2_0.config.AuthenticationApiModule;
 import org.jclouds.openstack.keystone.v2_0.config.CredentialTypes;
 import org.jclouds.openstack.keystone.v2_0.config.KeystoneAuthenticationModule;
-import org.jclouds.openstack.keystone.v2_0.config.KeystoneAuthenticationModule.ZoneModule;
+import org.jclouds.openstack.keystone.v2_0.config.KeystoneAuthenticationModule.RegionModule;
 import org.jclouds.openstack.v2_0.ServiceType;
 import org.jclouds.rest.internal.BaseHttpApiMetadata;
 
@@ -34,7 +34,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.inject.Module;
 
 /**
- * Implementation of {@link ApiMetadata} for Glance 1.0 API
+ * Implementation of {@link org.jclouds.apis.ApiMetadata} for Glance 1.0 API
  */
 public class GlanceApiMetadata extends BaseHttpApiMetadata<GlanceApi> {
 
@@ -73,10 +73,10 @@ public class GlanceApiMetadata extends BaseHttpApiMetadata<GlanceApi> {
          .defaultModules(ImmutableSet.<Class<? extends Module>>builder()
                                      .add(AuthenticationApiModule.class)
                                      .add(KeystoneAuthenticationModule.class)
-                                     .add(ZoneModule.class)
+                                     .add(RegionModule.class)
                                      .add(GlanceHttpApiModule.class).build());
       }
-      
+
       @Override
       public GlanceApiMetadata build() {
          return new GlanceApiMetadata(this);

--- a/openstack-glance/src/main/java/org/jclouds/openstack/glance/v1_0/functions/internal/ParseImageDetails.java
+++ b/openstack-glance/src/main/java/org/jclouds/openstack/glance/v1_0/functions/internal/ParseImageDetails.java
@@ -35,14 +35,14 @@ import org.jclouds.openstack.glance.v1_0.GlanceApi;
 import org.jclouds.openstack.glance.v1_0.domain.ImageDetails;
 import org.jclouds.openstack.glance.v1_0.features.ImageApi;
 import org.jclouds.openstack.glance.v1_0.functions.internal.ParseImageDetails.Images;
-import org.jclouds.openstack.v2_0.domain.PaginatedCollection;
 import org.jclouds.openstack.v2_0.domain.Link;
+import org.jclouds.openstack.v2_0.domain.PaginatedCollection;
+import org.jclouds.openstack.v2_0.options.PaginationOptions;
 
 import com.google.common.annotations.Beta;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.inject.TypeLiteral;
-import org.jclouds.openstack.v2_0.options.PaginationOptions;
 
 /**
  * boiler plate until we determine a better way
@@ -75,8 +75,8 @@ public class ParseImageDetails extends ParseJson<Images> {
 
       @Override
       protected Function<Object, IterableWithMarker<ImageDetails>> markerToNextForArg0(Optional<Object> arg0) {
-         String zone = arg0.isPresent() ? arg0.get().toString() : null;
-         final ImageApi imageApi = api.getImageApiForZone(zone);
+         String region = arg0.isPresent() ? arg0.get().toString() : null;
+         final ImageApi imageApi = api.getImageApi(region);
          return new Function<Object, IterableWithMarker<ImageDetails>>() {
 
             @SuppressWarnings("unchecked")
@@ -90,7 +90,7 @@ public class ParseImageDetails extends ParseJson<Images> {
                }
                else {
                   return IterableWithMarkers.EMPTY;
-               }                 
+               }
             }
 
             @Override

--- a/openstack-glance/src/main/java/org/jclouds/openstack/glance/v1_0/functions/internal/ParseImages.java
+++ b/openstack-glance/src/main/java/org/jclouds/openstack/glance/v1_0/functions/internal/ParseImages.java
@@ -35,14 +35,14 @@ import org.jclouds.openstack.glance.v1_0.GlanceApi;
 import org.jclouds.openstack.glance.v1_0.domain.Image;
 import org.jclouds.openstack.glance.v1_0.features.ImageApi;
 import org.jclouds.openstack.glance.v1_0.functions.internal.ParseImages.Images;
-import org.jclouds.openstack.v2_0.domain.PaginatedCollection;
 import org.jclouds.openstack.v2_0.domain.Link;
+import org.jclouds.openstack.v2_0.domain.PaginatedCollection;
+import org.jclouds.openstack.v2_0.options.PaginationOptions;
 
 import com.google.common.annotations.Beta;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.inject.TypeLiteral;
-import org.jclouds.openstack.v2_0.options.PaginationOptions;
 
 /**
  * boiler plate until we determine a better way
@@ -75,8 +75,8 @@ public class ParseImages extends ParseJson<Images> {
 
       @Override
       protected Function<Object, IterableWithMarker<Image>> markerToNextForArg0(Optional<Object> arg0) {
-         String zone = arg0.isPresent() ? arg0.get().toString() : null;
-         final ImageApi imageApi = api.getImageApiForZone(zone);
+         String region = arg0.isPresent() ? arg0.get().toString() : null;
+         final ImageApi imageApi = api.getImageApi(region);
          return new Function<Object, IterableWithMarker<Image>>() {
 
             @SuppressWarnings("unchecked")

--- a/openstack-glance/src/main/java/org/jclouds/openstack/glance/v1_0/handlers/GlanceErrorHandler.java
+++ b/openstack-glance/src/main/java/org/jclouds/openstack/glance/v1_0/handlers/GlanceErrorHandler.java
@@ -24,7 +24,7 @@ import org.jclouds.http.HttpCommand;
 import org.jclouds.http.HttpErrorHandler;
 import org.jclouds.http.HttpResponse;
 import org.jclouds.http.HttpResponseException;
-import org.jclouds.openstack.glance.functions.ZoneToEndpointNegotiateVersion;
+import org.jclouds.openstack.glance.functions.RegionToEndpointNegotiateVersion;
 import org.jclouds.rest.AuthorizationException;
 import org.jclouds.rest.ResourceNotFoundException;
 
@@ -46,7 +46,7 @@ public class GlanceErrorHandler implements HttpErrorHandler {
       switch (response.getStatusCode()) {
          // do not throw exceptions on Glance version negotiation
          case 300:
-            if (command.getCurrentRequest().getFirstHeaderOrNull(ZoneToEndpointNegotiateVersion.VERSION_NEGOTIATION_HEADER) != null) {
+            if (command.getCurrentRequest().getFirstHeaderOrNull(RegionToEndpointNegotiateVersion.VERSION_NEGOTIATION_HEADER) != null) {
                return;
             }
             break;

--- a/openstack-glance/src/test/java/org/jclouds/openstack/glance/v1_0/features/GlanceVersionNegotiationExpectTest.java
+++ b/openstack-glance/src/test/java/org/jclouds/openstack/glance/v1_0/features/GlanceVersionNegotiationExpectTest.java
@@ -53,7 +53,7 @@ public class GlanceVersionNegotiationExpectTest extends BaseGlanceExpectTest {
             responseWithKeystoneAccess, versionNegotiationRequest, versionNegotiationResponse,
             list, listResponse);
 
-      assertEquals(apiWhenExist.getImageApiForZone("az-1.region-a.geo-1").list().concat().toString(),
+      assertEquals(apiWhenExist.getImageApi("az-1.region-a.geo-1").list().concat().toString(),
             new ParseImagesTest().expected().toString());
    }
 
@@ -70,7 +70,7 @@ public class GlanceVersionNegotiationExpectTest extends BaseGlanceExpectTest {
       GlanceApi apiWhenExist = requestsSendResponses(keystoneAuthWithUsernameAndPassword,
             responseWithKeystoneAccess, versionNegotiationRequest, localVersionNegotiationResponse);
 
-      apiWhenExist.getImageApiForZone("az-1.region-a.geo-1").list();
+      apiWhenExist.getImageApi("az-1.region-a.geo-1").list();
    }
 
     /*
@@ -95,7 +95,7 @@ public class GlanceVersionNegotiationExpectTest extends BaseGlanceExpectTest {
             localResponseWithKeystoneAccess, versionNegotiationRequest, versionNegotiationResponse,
             list, listResponse);
 
-      assertEquals(apiWhenExist.getImageApiForZone("az-1.region-a.geo-1").list().concat().toString(),
+      assertEquals(apiWhenExist.getImageApi("az-1.region-a.geo-1").list().concat().toString(),
             new ParseImagesTest().expected().toString());
    }
 }

--- a/openstack-glance/src/test/java/org/jclouds/openstack/glance/v1_0/features/ImageApiExpectTest.java
+++ b/openstack-glance/src/test/java/org/jclouds/openstack/glance/v1_0/features/ImageApiExpectTest.java
@@ -58,9 +58,9 @@ public class ImageApiExpectTest extends BaseGlanceExpectTest {
             responseWithKeystoneAccess, versionNegotiationRequest, versionNegotiationResponse,
             list, listResponse);
 
-      assertEquals(apiWhenExist.getConfiguredZones(), ImmutableSet.of("az-1.region-a.geo-1"));
+      assertEquals(apiWhenExist.getConfiguredRegions(), ImmutableSet.of("az-1.region-a.geo-1"));
 
-      assertEquals(apiWhenExist.getImageApiForZone("az-1.region-a.geo-1").list().concat().toString(),
+      assertEquals(apiWhenExist.getImageApi("az-1.region-a.geo-1").list().concat().toString(),
             new ParseImagesTest().expected().toString());
    }
 
@@ -76,7 +76,7 @@ public class ImageApiExpectTest extends BaseGlanceExpectTest {
             responseWithKeystoneAccess, versionNegotiationRequest, versionNegotiationResponse,
             list, listResponse);
 
-      assertTrue(apiWhenNoExist.getImageApiForZone("az-1.region-a.geo-1").list().concat().isEmpty());
+      assertTrue(apiWhenNoExist.getImageApi("az-1.region-a.geo-1").list().concat().isEmpty());
    }
 
    public void testListInDetailWhenResponseIs2xx() throws Exception {
@@ -92,9 +92,9 @@ public class ImageApiExpectTest extends BaseGlanceExpectTest {
             responseWithKeystoneAccess, versionNegotiationRequest, versionNegotiationResponse,
             listInDetail, listInDetailResponse);
 
-      assertEquals(apiWhenExistInDetail.getConfiguredZones(), ImmutableSet.of("az-1.region-a.geo-1"));
+      assertEquals(apiWhenExistInDetail.getConfiguredRegions(), ImmutableSet.of("az-1.region-a.geo-1"));
 
-      assertEquals(apiWhenExistInDetail.getImageApiForZone("az-1.region-a.geo-1").listInDetail().concat().toString(),
+      assertEquals(apiWhenExistInDetail.getImageApi("az-1.region-a.geo-1").listInDetail().concat().toString(),
             new ParseImagesInDetailTest().expected().toString());
    }
 
@@ -110,7 +110,7 @@ public class ImageApiExpectTest extends BaseGlanceExpectTest {
             responseWithKeystoneAccess, versionNegotiationRequest, versionNegotiationResponse,
             listInDetail, listInDetailResponse);
 
-      assertTrue(apiWhenNoExistInDetail.getImageApiForZone("az-1.region-a.geo-1").listInDetail().concat().isEmpty());
+      assertTrue(apiWhenNoExistInDetail.getImageApi("az-1.region-a.geo-1").listInDetail().concat().isEmpty());
    }
 
    public void testShowWhenResponseIs2xx() throws Exception {
@@ -125,9 +125,9 @@ public class ImageApiExpectTest extends BaseGlanceExpectTest {
             responseWithKeystoneAccess, versionNegotiationRequest, versionNegotiationResponse,
             show, showResponse);
 
-      assertEquals(apiWhenExist.getConfiguredZones(), ImmutableSet.of("az-1.region-a.geo-1"));
+      assertEquals(apiWhenExist.getConfiguredRegions(), ImmutableSet.of("az-1.region-a.geo-1"));
 
-      assertEquals(apiWhenExist.getImageApiForZone("az-1.region-a.geo-1").get("fcc451d0-f6e4-4824-ad8f-70ec12326d07").toString(),
+      assertEquals(apiWhenExist.getImageApi("az-1.region-a.geo-1").get("fcc451d0-f6e4-4824-ad8f-70ec12326d07").toString(),
             new ParseImageDetailsFromHeadersTest().expected().toString());
    }
 
@@ -144,7 +144,7 @@ public class ImageApiExpectTest extends BaseGlanceExpectTest {
             responseWithKeystoneAccess, versionNegotiationRequest, versionNegotiationResponse,
             show, showResponse);
 
-      assertNull(apiWhenNoExist.getImageApiForZone("az-1.region-a.geo-1").get("fcc451d0-f6e4-4824-ad8f-70ec12326d07"));
+      assertNull(apiWhenNoExist.getImageApi("az-1.region-a.geo-1").get("fcc451d0-f6e4-4824-ad8f-70ec12326d07"));
    }
 
 
@@ -160,9 +160,9 @@ public class ImageApiExpectTest extends BaseGlanceExpectTest {
             responseWithKeystoneAccess, versionNegotiationRequest, versionNegotiationResponse,
             get, getResponse);
 
-      assertEquals(apiWhenExist.getConfiguredZones(), ImmutableSet.of("az-1.region-a.geo-1"));
+      assertEquals(apiWhenExist.getConfiguredRegions(), ImmutableSet.of("az-1.region-a.geo-1"));
 
-      assertEquals(Strings2.toStringAndClose(apiWhenExist.getImageApiForZone("az-1.region-a.geo-1").getAsStream("fcc451d0-f6e4-4824-ad8f-70ec12326d07")),
+      assertEquals(Strings2.toStringAndClose(apiWhenExist.getImageApi("az-1.region-a.geo-1").getAsStream("fcc451d0-f6e4-4824-ad8f-70ec12326d07")),
                "foo");
    }
 
@@ -178,7 +178,7 @@ public class ImageApiExpectTest extends BaseGlanceExpectTest {
             responseWithKeystoneAccess, versionNegotiationRequest, versionNegotiationResponse,
             get, getResponse);
 
-      assertNull(apiWhenNoExist.getImageApiForZone("az-1.region-a.geo-1").getAsStream("fcc451d0-f6e4-4824-ad8f-70ec12326d07"));
+      assertNull(apiWhenNoExist.getImageApi("az-1.region-a.geo-1").getAsStream("fcc451d0-f6e4-4824-ad8f-70ec12326d07"));
    }
 
    public void testCreateWhenResponseIs2xx() throws Exception {
@@ -196,9 +196,9 @@ public class ImageApiExpectTest extends BaseGlanceExpectTest {
             responseWithKeystoneAccess, versionNegotiationRequest, versionNegotiationResponse,
             get, createResponse);
 
-      assertEquals(apiWhenExist.getConfiguredZones(), ImmutableSet.of("az-1.region-a.geo-1"));
+      assertEquals(apiWhenExist.getConfiguredRegions(), ImmutableSet.of("az-1.region-a.geo-1"));
 
-      assertEquals(apiWhenExist.getImageApiForZone("az-1.region-a.geo-1").create("test", new StringPayload("somedata")),
+      assertEquals(apiWhenExist.getImageApi("az-1.region-a.geo-1").create("test", new StringPayload("somedata")),
             new ParseImageDetailsTest().expected());
    }
 
@@ -218,9 +218,9 @@ public class ImageApiExpectTest extends BaseGlanceExpectTest {
             responseWithKeystoneAccess, versionNegotiationRequest, versionNegotiationResponse,
             get, createResponse);
 
-      assertEquals(apiWhenExist.getConfiguredZones(), ImmutableSet.of("az-1.region-a.geo-1"));
+      assertEquals(apiWhenExist.getConfiguredRegions(), ImmutableSet.of("az-1.region-a.geo-1"));
 
-      apiWhenExist.getImageApiForZone("az-1.region-a.geo-1").create("test", new StringPayload("somedata"));
+      apiWhenExist.getImageApi("az-1.region-a.geo-1").create("test", new StringPayload("somedata"));
    }
 
    public void testReserveWhenResponseIs2xx() throws Exception {
@@ -237,9 +237,9 @@ public class ImageApiExpectTest extends BaseGlanceExpectTest {
             responseWithKeystoneAccess, versionNegotiationRequest, versionNegotiationResponse,
             get, createResponse);
 
-      assertEquals(apiWhenExist.getConfiguredZones(), ImmutableSet.of("az-1.region-a.geo-1"));
+      assertEquals(apiWhenExist.getConfiguredRegions(), ImmutableSet.of("az-1.region-a.geo-1"));
 
-      assertEquals(apiWhenExist.getImageApiForZone("az-1.region-a.geo-1").reserve("test"), new ParseImageDetailsTest().expected());
+      assertEquals(apiWhenExist.getImageApi("az-1.region-a.geo-1").reserve("test"), new ParseImageDetailsTest().expected());
    }
 
    @Test(expectedExceptions = AuthorizationException.class)
@@ -257,9 +257,9 @@ public class ImageApiExpectTest extends BaseGlanceExpectTest {
             responseWithKeystoneAccess, versionNegotiationRequest, versionNegotiationResponse,
             get, createResponse);
 
-      assertEquals(apiWhenExist.getConfiguredZones(), ImmutableSet.of("az-1.region-a.geo-1"));
+      assertEquals(apiWhenExist.getConfiguredRegions(), ImmutableSet.of("az-1.region-a.geo-1"));
 
-      apiWhenExist.getImageApiForZone("az-1.region-a.geo-1").reserve("test");
+      apiWhenExist.getImageApi("az-1.region-a.geo-1").reserve("test");
    }
 
    public void testUpdateMetadataWhenResponseIs2xx() throws Exception {
@@ -285,9 +285,9 @@ public class ImageApiExpectTest extends BaseGlanceExpectTest {
             responseWithKeystoneAccess, versionNegotiationRequest, versionNegotiationResponse,
             get, updateResponse);
 
-      assertEquals(apiWhenExist.getConfiguredZones(), ImmutableSet.of("az-1.region-a.geo-1"));
+      assertEquals(apiWhenExist.getConfiguredRegions(), ImmutableSet.of("az-1.region-a.geo-1"));
 
-      assertEquals(apiWhenExist.getImageApiForZone("az-1.region-a.geo-1")
+      assertEquals(apiWhenExist.getImageApi("az-1.region-a.geo-1")
             .update("fcc451d0-f6e4-4824-ad8f-70ec12326d07",
                   UpdateImageOptions.Builder.name("newname"),
                   UpdateImageOptions.Builder.isPublic(true),
@@ -317,9 +317,9 @@ public class ImageApiExpectTest extends BaseGlanceExpectTest {
             responseWithKeystoneAccess, versionNegotiationRequest, versionNegotiationResponse,
             get, updateResponse);
 
-      assertEquals(apiWhenExist.getConfiguredZones(), ImmutableSet.of("az-1.region-a.geo-1"));
+      assertEquals(apiWhenExist.getConfiguredRegions(), ImmutableSet.of("az-1.region-a.geo-1"));
 
-      apiWhenExist.getImageApiForZone("az-1.region-a.geo-1")
+      apiWhenExist.getImageApi("az-1.region-a.geo-1")
             .update("fcc451d0-f6e4-4824-ad8f-70ec12326d07",
                   UpdateImageOptions.Builder.name("newname"),
                   UpdateImageOptions.Builder.isPublic(true));
@@ -341,9 +341,9 @@ public class ImageApiExpectTest extends BaseGlanceExpectTest {
             responseWithKeystoneAccess, versionNegotiationRequest, versionNegotiationResponse,
             get, updateResponse);
 
-      assertEquals(apiWhenExist.getConfiguredZones(), ImmutableSet.of("az-1.region-a.geo-1"));
+      assertEquals(apiWhenExist.getConfiguredRegions(), ImmutableSet.of("az-1.region-a.geo-1"));
 
-      assertEquals(apiWhenExist.getImageApiForZone("az-1.region-a.geo-1").upload("fcc451d0-f6e4-4824-ad8f-70ec12326d07",
+      assertEquals(apiWhenExist.getImageApi("az-1.region-a.geo-1").upload("fcc451d0-f6e4-4824-ad8f-70ec12326d07",
             new StringPayload("somenewdata")), new ParseImageDetailsTest().expected());
    }
 
@@ -366,9 +366,9 @@ public class ImageApiExpectTest extends BaseGlanceExpectTest {
             responseWithKeystoneAccess, versionNegotiationRequest, versionNegotiationResponse,
             get, updateResponse);
 
-      assertEquals(apiWhenExist.getConfiguredZones(), ImmutableSet.of("az-1.region-a.geo-1"));
+      assertEquals(apiWhenExist.getConfiguredRegions(), ImmutableSet.of("az-1.region-a.geo-1"));
 
-      assertEquals(apiWhenExist.getImageApiForZone("az-1.region-a.geo-1").upload("fcc451d0-f6e4-4824-ad8f-70ec12326d07",
+      assertEquals(apiWhenExist.getImageApi("az-1.region-a.geo-1").upload("fcc451d0-f6e4-4824-ad8f-70ec12326d07",
             new StringPayload("somenewdata"), UpdateImageOptions.Builder.name("anothernewname")), new ParseImageDetailsTest().expected());
    }
 
@@ -390,9 +390,9 @@ public class ImageApiExpectTest extends BaseGlanceExpectTest {
             responseWithKeystoneAccess, versionNegotiationRequest, versionNegotiationResponse,
             get, updateResponse);
 
-      assertEquals(apiWhenExist.getConfiguredZones(), ImmutableSet.of("az-1.region-a.geo-1"));
+      assertEquals(apiWhenExist.getConfiguredRegions(), ImmutableSet.of("az-1.region-a.geo-1"));
 
-      apiWhenExist.getImageApiForZone("az-1.region-a.geo-1").upload("fcc451d0-f6e4-4824-ad8f-70ec12326d07",
+      apiWhenExist.getImageApi("az-1.region-a.geo-1").upload("fcc451d0-f6e4-4824-ad8f-70ec12326d07",
             new StringPayload("somenewdata"), UpdateImageOptions.Builder.name("anothernewname"));
    }
 
@@ -408,9 +408,9 @@ public class ImageApiExpectTest extends BaseGlanceExpectTest {
             responseWithKeystoneAccess, versionNegotiationRequest, versionNegotiationResponse,
             get, getResponse);
 
-      assertEquals(apiWhenExist.getConfiguredZones(), ImmutableSet.of("az-1.region-a.geo-1"));
+      assertEquals(apiWhenExist.getConfiguredRegions(), ImmutableSet.of("az-1.region-a.geo-1"));
 
-      assertTrue(apiWhenExist.getImageApiForZone("az-1.region-a.geo-1").delete("fcc451d0-f6e4-4824-ad8f-70ec12326d07"));
+      assertTrue(apiWhenExist.getImageApi("az-1.region-a.geo-1").delete("fcc451d0-f6e4-4824-ad8f-70ec12326d07"));
    }
 
    public void testDeleteWhenResponseIs4xx() throws Exception {
@@ -426,8 +426,8 @@ public class ImageApiExpectTest extends BaseGlanceExpectTest {
             responseWithKeystoneAccess, versionNegotiationRequest, versionNegotiationResponse,
             get, getResponse);
 
-      assertEquals(apiWhenExist.getConfiguredZones(), ImmutableSet.of("az-1.region-a.geo-1"));
+      assertEquals(apiWhenExist.getConfiguredRegions(), ImmutableSet.of("az-1.region-a.geo-1"));
 
-      assertFalse(apiWhenExist.getImageApiForZone("az-1.region-a.geo-1").delete("fcc451d0-f6e4-4824-ad8f-70ec12326d07"));
+      assertFalse(apiWhenExist.getImageApi("az-1.region-a.geo-1").delete("fcc451d0-f6e4-4824-ad8f-70ec12326d07"));
    }
 }

--- a/openstack-glance/src/test/java/org/jclouds/openstack/glance/v1_0/features/ImageApiLiveTest.java
+++ b/openstack-glance/src/test/java/org/jclouds/openstack/glance/v1_0/features/ImageApiLiveTest.java
@@ -41,8 +41,8 @@ public class ImageApiLiveTest extends BaseGlanceApiLiveTest {
 
    @Test
    public void testList() throws Exception {
-      for (String zoneId : api.getConfiguredZones()) {
-         ImageApi imageApi = api.getImageApiForZone(zoneId);
+      for (String region : api.getConfiguredRegions()) {
+         ImageApi imageApi = api.getImageApi(region);
          Set<? extends Image> response = imageApi.list().concat().toSet();
          assert null != response;
          for (Image image : response) {
@@ -59,8 +59,8 @@ public class ImageApiLiveTest extends BaseGlanceApiLiveTest {
 
    @Test
    public void testListInDetail() throws Exception {
-      for (String zoneId : api.getConfiguredZones()) {
-         ImageApi imageApi = api.getImageApiForZone(zoneId);
+      for (String region : api.getConfiguredRegions()) {
+         ImageApi imageApi = api.getImageApi(region);
          Set<? extends ImageDetails> response = imageApi.listInDetail().concat().toSet();
          assert null != response;
          for (ImageDetails image : response) {
@@ -87,16 +87,16 @@ public class ImageApiLiveTest extends BaseGlanceApiLiveTest {
    @Test
    public void testCreateUpdateAndDeleteImage() {
       StringPayload imageData = new StringPayload("This isn't really an image!");
-      for (String zoneId : api.getConfiguredZones()) {
-         ImageApi imageApi = api.getImageApiForZone(zoneId);
+      for (String region : api.getConfiguredRegions()) {
+         ImageApi imageApi = api.getImageApi(region);
          ImageDetails details = imageApi.create("jclouds-live-test", imageData, diskFormat(DiskFormat.RAW), containerFormat(ContainerFormat.BARE));
          assertEquals(details.getName(), "jclouds-live-test");
          assertEquals(details.getSize().get().longValue(), imageData.getRawContent().length());
-         
+
          details = imageApi.update(details.getId(), UpdateImageOptions.Builder.name("jclouds-live-test2"), UpdateImageOptions.Builder.minDisk(10));
          assertEquals(details.getName(), "jclouds-live-test2");
          assertEquals(details.getMinDisk(), 10);
-         
+
          Image fromListing = imageApi.list(
                   ListImageOptions.Builder.containerFormat(ContainerFormat.BARE).name("jclouds-live-test2").limit(2))
                   .get(0);
@@ -106,7 +106,7 @@ public class ImageApiLiveTest extends BaseGlanceApiLiveTest {
          assertEquals(Iterables.getOnlyElement(imageApi.listInDetail(ListImageOptions.Builder.name("jclouds-live-test2"))), details);
 
          assertTrue(imageApi.delete(details.getId()));
-         
+
          assertTrue(imageApi.list(ListImageOptions.Builder.name("jclouds-live-test2")).isEmpty());
       }
    }
@@ -114,11 +114,11 @@ public class ImageApiLiveTest extends BaseGlanceApiLiveTest {
    @Test
    public void testReserveUploadAndDeleteImage() {
       StringPayload imageData = new StringPayload("This isn't an image!");
-      for (String zoneId : api.getConfiguredZones()) {
-         ImageApi imageApi = api.getImageApiForZone(zoneId);
+      for (String region : api.getConfiguredRegions()) {
+         ImageApi imageApi = api.getImageApi(region);
          ImageDetails details = imageApi.reserve("jclouds-live-res-test", diskFormat(DiskFormat.RAW), containerFormat(ContainerFormat.BARE));
          assertEquals(details.getName(), "jclouds-live-res-test");
- 
+
          details = imageApi.upload(details.getId(), imageData, UpdateImageOptions.Builder.name("jclouds-live-res-test2"), UpdateImageOptions.Builder.minDisk(10));
          assertEquals(details.getName(), "jclouds-live-res-test2");
          assertEquals(details.getSize().get().longValue(), imageData.getRawContent().length());

--- a/openstack-glance/src/test/java/org/jclouds/openstack/glance/v1_0/internal/BaseGlanceExpectTest.java
+++ b/openstack-glance/src/test/java/org/jclouds/openstack/glance/v1_0/internal/BaseGlanceExpectTest.java
@@ -18,7 +18,7 @@ package org.jclouds.openstack.glance.v1_0.internal;
 
 import org.jclouds.http.HttpRequest;
 import org.jclouds.http.HttpResponse;
-import org.jclouds.openstack.glance.functions.ZoneToEndpointNegotiateVersion;
+import org.jclouds.openstack.glance.functions.RegionToEndpointNegotiateVersion;
 import org.jclouds.openstack.glance.v1_0.GlanceApi;
 import org.jclouds.openstack.keystone.v2_0.internal.KeystoneFixture;
 import org.jclouds.rest.internal.BaseRestApiExpectTest;
@@ -50,7 +50,7 @@ public abstract class BaseGlanceExpectTest extends BaseRestApiExpectTest<GlanceA
       // version negotiation
       versionNegotiationRequest = HttpRequest.builder().method("GET")
             .endpoint("https://glance.jclouds.org:9292/")
-            .addHeader(ZoneToEndpointNegotiateVersion.VERSION_NEGOTIATION_HEADER, "true").build();
+            .addHeader(RegionToEndpointNegotiateVersion.VERSION_NEGOTIATION_HEADER, "true").build();
       versionNegotiationResponse = HttpResponse.builder().statusCode(300).message("HTTP/1.1 300 Multiple Choices").payload(
             payloadFromResourceWithContentType("/glanceVersionResponse.json", "application/json")).build();
    }

--- a/openstack-marconi/src/main/java/org/jclouds/openstack/marconi/v1/MarconiApi.java
+++ b/openstack-marconi/src/main/java/org/jclouds/openstack/marconi/v1/MarconiApi.java
@@ -16,32 +16,91 @@
  */
 package org.jclouds.openstack.marconi.v1;
 
-import com.google.inject.Provides;
+import java.io.Closeable;
+import java.util.Set;
+import java.util.UUID;
+
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
 import org.jclouds.javax.annotation.Nullable;
-import org.jclouds.location.Zone;
-import org.jclouds.location.functions.ZoneToEndpoint;
+import org.jclouds.location.Region;
+import org.jclouds.location.functions.RegionToEndpoint;
 import org.jclouds.openstack.marconi.v1.features.ClaimApi;
 import org.jclouds.openstack.marconi.v1.features.MessageApi;
 import org.jclouds.openstack.marconi.v1.features.QueueApi;
 import org.jclouds.rest.annotations.Delegate;
 import org.jclouds.rest.annotations.EndpointParam;
 
-import javax.ws.rs.HeaderParam;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import java.io.Closeable;
-import java.util.Set;
-import java.util.UUID;
+import com.google.inject.Provides;
 
 /**
  * Marconi is a robust, web-scale message queuing service to support the distributed nature of large web applications.
  */
 public interface MarconiApi extends Closeable {
    /**
-    * @return The Zone codes configured
+    * @return the Region codes configured
     */
    @Provides
-   @Zone
+   @Region
+   Set<String> getConfiguredRegions();
+
+   /**
+    * Provides access to Queue features.
+    *
+    * @param region   The region where this queue will live.
+    * @param clientId A UUID for each client instance. The UUID must be submitted in its canonical form (for example,
+    *                 3381af92-2b9e-11e3-b191-71861300734c). The client generates the Client-ID once. Client-ID
+    *                 persists between restarts of the client so the client should reuse that same Client-ID. All
+    *                 message-related operations require the use of Client-ID in the headers to ensure that messages
+    *                 are not echoed back to the client that posted them, unless the client explicitly requests this.
+    */
+   @Delegate
+   QueueApi getQueueApi(@EndpointParam(parser = RegionToEndpoint.class) @Nullable String region,
+         @HeaderParam("Client-ID") UUID clientId);
+
+   /**
+    * Provides access to Message features.
+    *
+    * @param region   The region where this queue lives.
+    * @param clientId A UUID for each client instance. The UUID must be submitted in its canonical form (for example,
+    *                 3381af92-2b9e-11e3-b191-71861300734c). The client generates the Client-ID once. Client-ID
+    *                 persists between restarts of the client so the client should reuse that same Client-ID. All
+    *                 message-related operations require the use of Client-ID in the headers to ensure that messages
+    *                 are not echoed back to the client that posted them, unless the client explicitly requests this.
+    * @param name     Name of the queue.
+    */
+   @Delegate
+   @Path("/queues/{name}")
+   MessageApi getMessageApi(@EndpointParam(parser = RegionToEndpoint.class) @Nullable String region,
+         @HeaderParam("Client-ID") UUID clientId,
+         @PathParam("name") String name);
+
+   /**
+    * Provides access to Claim features.
+    *
+    * @param region   The region where this queue lives.
+    * @param clientId A UUID for each client instance. The UUID must be submitted in its canonical form (for example,
+    *                 3381af92-2b9e-11e3-b191-71861300734c). The client generates the Client-ID once. Client-ID
+    *                 persists between restarts of the client so the client should reuse that same Client-ID. All
+    *                 message-related operations require the use of Client-ID in the headers to ensure that messages
+    *                 are not echoed back to the client that posted them, unless the client explicitly requests this.
+    * @param name     Name of the queue.
+    */
+   @Delegate
+   @Path("/queues/{name}")
+   ClaimApi getClaimApi(@EndpointParam(parser = RegionToEndpoint.class) @Nullable String region,
+         @HeaderParam("Client-ID") UUID clientId,
+         @PathParam("name") String name);
+
+   /**
+    * @return the Zone codes configured
+    * @deprecated Please use {@link #getConfiguredRegions()} as this method will be removed in jclouds 3.0.
+    */
+   @Deprecated
+   @Provides
+   @Region
    Set<String> getConfiguredZones();
 
    /**
@@ -53,10 +112,13 @@ public interface MarconiApi extends Closeable {
     *                 persists between restarts of the client so the client should reuse that same Client-ID. All
     *                 message-related operations require the use of Client-ID in the headers to ensure that messages
     *                 are not echoed back to the client that posted them, unless the client explicitly requests this.
+    * @deprecated Please use {@link #getQueueApi(String, UUID)} as this method will be removed
+    *             in jclouds 3.0.
     */
+   @Deprecated
    @Delegate
    QueueApi getQueueApiForZoneAndClient(
-         @EndpointParam(parser = ZoneToEndpoint.class) @Nullable String zone,
+         @EndpointParam(parser = RegionToEndpoint.class) @Nullable String zone,
          @HeaderParam("Client-ID") UUID clientId);
 
    /**
@@ -69,11 +131,14 @@ public interface MarconiApi extends Closeable {
     *                 message-related operations require the use of Client-ID in the headers to ensure that messages
     *                 are not echoed back to the client that posted them, unless the client explicitly requests this.
     * @param name     Name of the queue.
+    * @deprecated Please use {@link #getMessageApi(String, UUID, String)} as this method will be removed
+    *             in jclouds 3.0.
     */
+   @Deprecated
    @Delegate
    @Path("/queues/{name}")
    MessageApi getMessageApiForZoneAndClientAndQueue(
-         @EndpointParam(parser = ZoneToEndpoint.class) @Nullable String zone,
+         @EndpointParam(parser = RegionToEndpoint.class) @Nullable String zone,
          @HeaderParam("Client-ID") UUID clientId,
          @PathParam("name") String name);
 
@@ -87,11 +152,14 @@ public interface MarconiApi extends Closeable {
     *                 message-related operations require the use of Client-ID in the headers to ensure that messages
     *                 are not echoed back to the client that posted them, unless the client explicitly requests this.
     * @param name     Name of the queue.
+    * @deprecated Please use {@link #getClaimApi(String, UUID, String)} as this method will be removed
+    *             in jclouds 3.0.
     */
+   @Deprecated
    @Delegate
    @Path("/queues/{name}")
    ClaimApi getClaimApiForZoneAndClientAndQueue(
-         @EndpointParam(parser = ZoneToEndpoint.class) @Nullable String zone,
+         @EndpointParam(parser = RegionToEndpoint.class) @Nullable String zone,
          @HeaderParam("Client-ID") UUID clientId,
          @PathParam("name") String name);
 }

--- a/openstack-marconi/src/main/java/org/jclouds/openstack/marconi/v1/MarconiApiMetadata.java
+++ b/openstack-marconi/src/main/java/org/jclouds/openstack/marconi/v1/MarconiApiMetadata.java
@@ -16,24 +16,24 @@
  */
 package org.jclouds.openstack.marconi.v1;
 
-import com.google.common.collect.ImmutableSet;
-import com.google.inject.Module;
+import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.CREDENTIAL_TYPE;
+import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.SERVICE_TYPE;
+
+import java.net.URI;
+import java.util.Properties;
 
 import org.jclouds.http.okhttp.config.OkHttpCommandExecutorServiceModule;
 import org.jclouds.openstack.keystone.v2_0.config.AuthenticationApiModule;
 import org.jclouds.openstack.keystone.v2_0.config.CredentialTypes;
 import org.jclouds.openstack.keystone.v2_0.config.KeystoneAuthenticationModule;
-import org.jclouds.openstack.keystone.v2_0.config.KeystoneAuthenticationModule.ZoneModule;
+import org.jclouds.openstack.keystone.v2_0.config.KeystoneAuthenticationModule.RegionModule;
 import org.jclouds.openstack.marconi.v1.config.MarconiHttpApiModule;
 import org.jclouds.openstack.marconi.v1.config.MarconiTypeAdapters;
 import org.jclouds.openstack.v2_0.ServiceType;
 import org.jclouds.rest.internal.BaseHttpApiMetadata;
 
-import java.net.URI;
-import java.util.Properties;
-
-import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.CREDENTIAL_TYPE;
-import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.SERVICE_TYPE;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Module;
 
 /**
  * Implementation of {@link org.jclouds.apis.ApiMetadata} for Marconi 1.0 API
@@ -77,11 +77,11 @@ public class MarconiApiMetadata extends BaseHttpApiMetadata<MarconiApi> {
                                      .add(AuthenticationApiModule.class)
                                      .add(KeystoneAuthenticationModule.class)
                                      .add(OkHttpCommandExecutorServiceModule.class)
-                                     .add(ZoneModule.class)
+                                     .add(RegionModule.class)
                                      .add(MarconiTypeAdapters.class)
                                      .add(MarconiHttpApiModule.class).build());
       }
-      
+
       @Override
       public MarconiApiMetadata build() {
          return new MarconiApiMetadata(this);

--- a/openstack-marconi/src/main/java/org/jclouds/openstack/marconi/v1/features/MessageApi.java
+++ b/openstack-marconi/src/main/java/org/jclouds/openstack/marconi/v1/features/MessageApi.java
@@ -16,6 +16,23 @@
  */
 package org.jclouds.openstack.marconi.v1.features;
 
+import java.util.List;
+
+import javax.inject.Named;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import org.jclouds.Fallbacks.EmptyListOnNotFoundOr404;
+import org.jclouds.Fallbacks.FalseOnNotFoundOr404;
+import org.jclouds.Fallbacks.NullOnNotFoundOr404;
+import org.jclouds.javax.annotation.Nullable;
+import org.jclouds.openstack.keystone.v2_0.KeystoneFallbacks.EmptyPaginatedCollectionOnNotFoundOr404;
 import org.jclouds.openstack.keystone.v2_0.filters.AuthenticateRequest;
 import org.jclouds.openstack.marconi.v1.binders.BindIdsToQueryParam;
 import org.jclouds.openstack.marconi.v1.domain.CreateMessage;
@@ -34,27 +51,13 @@ import org.jclouds.rest.annotations.ResponseParser;
 import org.jclouds.rest.annotations.SkipEncoding;
 import org.jclouds.rest.binders.BindToJsonPayload;
 
-import javax.inject.Named;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
-import java.util.List;
-
-import static org.jclouds.Fallbacks.EmptyListOnNotFoundOr404;
-import static org.jclouds.Fallbacks.FalseOnNotFoundOr404;
-import static org.jclouds.Fallbacks.NullOnNotFoundOr404;
-import static org.jclouds.openstack.keystone.v2_0.KeystoneFallbacks.EmptyPaginatedCollectionOnNotFoundOr404;
-
 /**
  * Provides access to Messages via their REST API.
  */
 @SkipEncoding({'/', '='})
 @RequestFilters(AuthenticateRequest.class)
+@Consumes(MediaType.APPLICATION_JSON)
+@Path("/messages")
 public interface MessageApi {
    /**
     * Create message(s) on a queue.
@@ -64,9 +67,9 @@ public interface MessageApi {
     */
    @Named("message:create")
    @POST
-   @Path("/messages")
    @ResponseParser(ParseMessagesCreated.class)
    @Fallback(NullOnNotFoundOr404.class)
+   @Nullable
    MessagesCreated create(@BinderParam(BindToJsonPayload.class) List<CreateMessage> messages);
 
    /**
@@ -78,9 +81,7 @@ public interface MessageApi {
    @Named("message:stream")
    @GET
    @ResponseParser(ParseMessagesToStream.class)
-   @Consumes(MediaType.APPLICATION_JSON)
    @Fallback(EmptyPaginatedCollectionOnNotFoundOr404.class)
-   @Path("/messages")
    MessageStream stream(StreamMessagesOptions... options);
 
    /**
@@ -91,8 +92,6 @@ public interface MessageApi {
    @Named("message:list")
    @GET
    @ResponseParser(ParseMessagesToList.class)
-   @Consumes(MediaType.APPLICATION_JSON)
-   @Path("/messages")
    @Fallback(EmptyListOnNotFoundOr404.class)
    List<Message> list(@BinderParam(BindIdsToQueryParam.class) Iterable<String> ids);
 
@@ -103,10 +102,10 @@ public interface MessageApi {
     */
    @Named("message:get")
    @GET
+   @Path("/{message_id}")
    @ResponseParser(ParseMessage.class)
-   @Consumes(MediaType.APPLICATION_JSON)
-   @Path("/messages/{message_id}")
    @Fallback(NullOnNotFoundOr404.class)
+   @Nullable
    Message get(@PathParam("message_id") String id);
 
    /**
@@ -117,8 +116,6 @@ public interface MessageApi {
     */
    @Named("message:delete")
    @DELETE
-   @Consumes(MediaType.APPLICATION_JSON)
-   @Path("/messages")
    @Fallback(FalseOnNotFoundOr404.class)
    boolean delete(@BinderParam(BindIdsToQueryParam.class) Iterable<String> ids);
 
@@ -133,8 +130,7 @@ public interface MessageApi {
     */
    @Named("message:delete")
    @DELETE
-   @Consumes(MediaType.APPLICATION_JSON)
-   @Path("/messages/{message_id}")
+   @Path("/{message_id}")
    @Fallback(FalseOnNotFoundOr404.class)
    boolean deleteByClaim(@PathParam("message_id") String id,
                          @QueryParam("claim_id") String claimId);

--- a/openstack-marconi/src/main/java/org/jclouds/openstack/marconi/v1/features/QueueApi.java
+++ b/openstack-marconi/src/main/java/org/jclouds/openstack/marconi/v1/features/QueueApi.java
@@ -16,6 +16,21 @@
  */
 package org.jclouds.openstack.marconi.v1.features;
 
+import java.util.Map;
+
+import javax.inject.Named;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import org.jclouds.Fallbacks.EmptyPagedIterableOnNotFoundOr404;
+import org.jclouds.Fallbacks.FalseOnNotFoundOr404;
 import org.jclouds.collect.PagedIterable;
 import org.jclouds.openstack.keystone.v2_0.filters.AuthenticateRequest;
 import org.jclouds.openstack.marconi.v1.domain.Queue;
@@ -34,26 +49,13 @@ import org.jclouds.rest.annotations.SkipEncoding;
 import org.jclouds.rest.annotations.Transform;
 import org.jclouds.rest.binders.BindToJsonPayload;
 
-import javax.inject.Named;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
-import java.util.Map;
-
-import static org.jclouds.Fallbacks.EmptyPagedIterableOnNotFoundOr404;
-import static org.jclouds.Fallbacks.FalseOnNotFoundOr404;
-
 /**
  * Provides access to Queues via their REST API.
  */
 @SkipEncoding({'/', '='})
 @RequestFilters(AuthenticateRequest.class)
+@Consumes(MediaType.APPLICATION_JSON)
+@Path("/queues")
 public interface QueueApi {
    /**
     * Create a queue.
@@ -63,7 +65,7 @@ public interface QueueApi {
     */
    @Named("queue:create")
    @PUT
-   @Path("queues/{name}")
+   @Path("/{name}")
    @Fallback(FalseOnNotFoundOr404.class)
    boolean create(@PathParam("name") String name);
 
@@ -75,7 +77,7 @@ public interface QueueApi {
     */
    @Named("queue:delete")
    @DELETE
-   @Path("queues/{name}")
+   @Path("/{name}")
    @Fallback(FalseOnNotFoundOr404.class)
    boolean delete(@PathParam("name") String name);
 
@@ -87,7 +89,7 @@ public interface QueueApi {
     */
    @Named("queue:get")
    @GET
-   @Path("queues/{name}")
+   @Path("/{name}")
    @Fallback(FalseOnNotFoundOr404.class)
    boolean exists(@PathParam("name") String name);
 
@@ -98,10 +100,8 @@ public interface QueueApi {
     */
    @Named("queue:list")
    @GET
-   @Consumes(MediaType.APPLICATION_JSON)
    @ResponseParser(ParseQueues.class)
    @Transform(QueuesToPagedIterable.class)
-   @Path("queues")
    @Fallback(EmptyPagedIterableOnNotFoundOr404.class)
    PagedIterable<Queue> list(@QueryParam("detailed") boolean detailed);
 
@@ -111,9 +111,7 @@ public interface QueueApi {
    @Named("queue:list")
    @GET
    @ResponseParser(ParseQueues.class)
-   @Consumes(MediaType.APPLICATION_JSON)
    @Fallback(EmptyQueuesFallback.class)
-   @Path("queues")
    Queues list(ListQueuesOptions options);
 
    /**
@@ -130,7 +128,7 @@ public interface QueueApi {
     */
    @Named("queue:setMetadata")
    @PUT
-   @Path("queues/{name}/metadata")
+   @Path("/{name}/metadata")
    @Produces(MediaType.APPLICATION_JSON)
    @Fallback(FalseOnNotFoundOr404.class)
    boolean setMetadata(@PathParam("name") String name,
@@ -144,8 +142,7 @@ public interface QueueApi {
     */
    @Named("queue:getMetadata")
    @GET
-   @Path("queues/{name}/metadata")
-   @Consumes(MediaType.APPLICATION_JSON)
+   @Path("/{name}/metadata")
    @Fallback(FalseOnNotFoundOr404.class)
    Map<String, String> getMetadata(@PathParam("name") String name);
 
@@ -158,8 +155,7 @@ public interface QueueApi {
     */
    @Named("queue:getStats")
    @GET
-   @Path("queues/{name}/stats")
-   @Consumes(MediaType.APPLICATION_JSON)
+   @Path("/{name}/stats")
    @ResponseParser(ParseQueueStats.class)
    @Fallback(FalseOnNotFoundOr404.class)
    QueueStats getStats(@PathParam("name") String name);

--- a/openstack-marconi/src/main/java/org/jclouds/openstack/marconi/v1/functions/QueuesToPagedIterable.java
+++ b/openstack-marconi/src/main/java/org/jclouds/openstack/marconi/v1/functions/QueuesToPagedIterable.java
@@ -46,10 +46,10 @@ public class QueuesToPagedIterable extends ArgsToPagedIterable.FromCaller<Queue,
 
    @Override
    protected Function<Object, IterableWithMarker<Queue>> markerToNextForArgs(List<Object> args) {
-      String zone = String.class.cast(args.get(0));
+      String region = String.class.cast(args.get(0));
       UUID clientId = UUID.class.cast(args.get(1));
 
-      return new ListQueuesAtMarker(api.getQueueApiForZoneAndClient(zone, clientId));
+      return new ListQueuesAtMarker(api.getQueueApi(region, clientId));
    }
 
    private static class ListQueuesAtMarker implements Function<Object, IterableWithMarker<Queue>> {

--- a/openstack-marconi/src/test/java/org/jclouds/openstack/marconi/v1/features/ClaimApiLiveTest.java
+++ b/openstack-marconi/src/test/java/org/jclouds/openstack/marconi/v1/features/ClaimApiLiveTest.java
@@ -41,8 +41,8 @@ public class ClaimApiLiveTest extends BaseMarconiApiLiveTest {
    private final Map<String, List<String>> claimIds = Maps.newHashMap();
 
    public void createQueues() throws Exception {
-      for (String zoneId : zones) {
-         QueueApi queueApi = api.getQueueApiForZoneAndClient(zoneId, CLIENT_ID);
+      for (String regionId : regions) {
+         QueueApi queueApi = api.getQueueApi(regionId, CLIENT_ID);
          boolean success = queueApi.create("jclouds-test");
 
          assertTrue(success);
@@ -51,8 +51,8 @@ public class ClaimApiLiveTest extends BaseMarconiApiLiveTest {
 
    @Test(dependsOnMethods = { "createQueues" })
    public void createMessages() throws Exception {
-      for (String zoneId : zones) {
-         MessageApi messageApi = api.getMessageApiForZoneAndClientAndQueue(zoneId, CLIENT_ID, "jclouds-test");
+      for (String regionId : regions) {
+         MessageApi messageApi = api.getMessageApi(regionId, CLIENT_ID, "jclouds-test");
 
          String json1 = "{\"event\":{\"name\":\"Austin Java User Group\",\"attendees\":[\"bob\",\"jim\",\"sally\"]}}";
          CreateMessage message1 = CreateMessage.builder().ttl(86400).body(json1).build();
@@ -71,16 +71,16 @@ public class ClaimApiLiveTest extends BaseMarconiApiLiveTest {
 
    @Test(dependsOnMethods = { "createMessages" })
    public void claimMessages() throws Exception {
-      for (String zoneId : zones) {
-         ClaimApi claimApi = api.getClaimApiForZoneAndClientAndQueue(zoneId, CLIENT_ID, "jclouds-test");
+      for (String regionId : regions) {
+         ClaimApi claimApi = api.getClaimApi(regionId, CLIENT_ID, "jclouds-test");
 
          List<Message> messages = claimApi.claim(300, 200, 2);
          assertEquals(messages.size(), 2);
 
-         claimIds.put(zoneId, new ArrayList<String>());
+         claimIds.put(regionId, new ArrayList<String>());
 
          for (Message message : messages) {
-            claimIds.get(zoneId).add(message.getClaimId().get());
+            claimIds.get(regionId).add(message.getClaimId().get());
 
             assertNotNull(message.getId());
             assertTrue(message.getClaimId().isPresent());
@@ -91,10 +91,10 @@ public class ClaimApiLiveTest extends BaseMarconiApiLiveTest {
 
    @Test(dependsOnMethods = { "claimMessages" })
    public void getClaim() throws Exception {
-      for (String zoneId : zones) {
-         ClaimApi claimApi = api.getClaimApiForZoneAndClientAndQueue(zoneId, CLIENT_ID, "jclouds-test");
+      for (String regionId : regions) {
+         ClaimApi claimApi = api.getClaimApi(regionId, CLIENT_ID, "jclouds-test");
 
-         Claim claim = claimApi.get(claimIds.get(zoneId).get(0));
+         Claim claim = claimApi.get(claimIds.get(regionId).get(0));
 
          assertNotNull(claim.getId());
          assertEquals(claim.getMessages().size(), 2);
@@ -110,10 +110,10 @@ public class ClaimApiLiveTest extends BaseMarconiApiLiveTest {
 
    @Test(dependsOnMethods = { "getClaim" })
    public void updateClaim() throws Exception {
-      for (String zoneId : zones) {
-         ClaimApi claimApi = api.getClaimApiForZoneAndClientAndQueue(zoneId, CLIENT_ID, "jclouds-test");
+      for (String regionId : regions) {
+         ClaimApi claimApi = api.getClaimApi(regionId, CLIENT_ID, "jclouds-test");
 
-         boolean success = claimApi.update(claimIds.get(zoneId).get(0), 400);
+         boolean success = claimApi.update(claimIds.get(regionId).get(0), 400);
 
          assertTrue(success);
       }
@@ -121,10 +121,10 @@ public class ClaimApiLiveTest extends BaseMarconiApiLiveTest {
 
    @Test(dependsOnMethods = { "updateClaim" })
    public void releaseClaim() throws Exception {
-      for (String zoneId : zones) {
-         ClaimApi claimApi = api.getClaimApiForZoneAndClientAndQueue(zoneId, CLIENT_ID, "jclouds-test");
+      for (String regionId : regions) {
+         ClaimApi claimApi = api.getClaimApi(regionId, CLIENT_ID, "jclouds-test");
 
-         boolean success = claimApi.release(claimIds.get(zoneId).get(0));
+         boolean success = claimApi.release(claimIds.get(regionId).get(0));
 
          assertTrue(success);
       }
@@ -132,8 +132,8 @@ public class ClaimApiLiveTest extends BaseMarconiApiLiveTest {
 
    @Test(dependsOnMethods = { "releaseClaim" })
    public void delete() throws Exception {
-      for (String zoneId : zones) {
-         QueueApi queueApi = api.getQueueApiForZoneAndClient(zoneId, CLIENT_ID);
+      for (String regionId : regions) {
+         QueueApi queueApi = api.getQueueApi(regionId, CLIENT_ID);
          boolean success = queueApi.delete("jclouds-test");
 
          assertTrue(success);

--- a/openstack-marconi/src/test/java/org/jclouds/openstack/marconi/v1/features/ClaimApiMockTest.java
+++ b/openstack-marconi/src/test/java/org/jclouds/openstack/marconi/v1/features/ClaimApiMockTest.java
@@ -41,7 +41,7 @@ public class ClaimApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
 
       try {
          MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
-         ClaimApi claimApi = api.getClaimApiForZoneAndClientAndQueue("DFW", CLIENT_ID, "jclouds-test");
+         ClaimApi claimApi = api.getClaimApi("DFW", CLIENT_ID, "jclouds-test");
 
          List<Message> messages = claimApi.claim(300, 200, 2);
 
@@ -69,7 +69,7 @@ public class ClaimApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
 
       try {
          MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
-         ClaimApi claimApi = api.getClaimApiForZoneAndClientAndQueue("DFW", CLIENT_ID, "jclouds-test");
+         ClaimApi claimApi = api.getClaimApi("DFW", CLIENT_ID, "jclouds-test");
 
          Claim claim = claimApi.get("52a8d23eb04a584f1bbd4f47");
 
@@ -110,7 +110,7 @@ public class ClaimApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
 
       try {
          MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
-         ClaimApi claimApi = api.getClaimApiForZoneAndClientAndQueue("DFW", CLIENT_ID, "jclouds-test");
+         ClaimApi claimApi = api.getClaimApi("DFW", CLIENT_ID, "jclouds-test");
 
          boolean success = claimApi.update("52a8d23eb04a584f1bbd4f47", 400);
 
@@ -132,7 +132,7 @@ public class ClaimApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
 
       try {
          MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
-         ClaimApi claimApi = api.getClaimApiForZoneAndClientAndQueue("DFW", CLIENT_ID, "jclouds-test");
+         ClaimApi claimApi = api.getClaimApi("DFW", CLIENT_ID, "jclouds-test");
 
          boolean success = claimApi.release("52a8d23eb04a584f1bbd4f47");
 

--- a/openstack-marconi/src/test/java/org/jclouds/openstack/marconi/v1/features/MessageApiLiveTest.java
+++ b/openstack-marconi/src/test/java/org/jclouds/openstack/marconi/v1/features/MessageApiLiveTest.java
@@ -46,8 +46,8 @@ public class MessageApiLiveTest extends BaseMarconiApiLiveTest {
    private final Map<String, List<String>> messageIds = Maps.newHashMap();
 
    public void createQueues() throws Exception {
-      for (String zoneId : zones) {
-         QueueApi queueApi = api.getQueueApiForZoneAndClient(zoneId, CLIENT_ID);
+      for (String regionId : regions) {
+         QueueApi queueApi = api.getQueueApi(regionId, CLIENT_ID);
          boolean success = queueApi.create("jclouds-test");
 
          assertTrue(success);
@@ -56,8 +56,8 @@ public class MessageApiLiveTest extends BaseMarconiApiLiveTest {
 
    @Test(dependsOnMethods = { "createQueues" })
    public void streamZeroPagesOfMessages() throws Exception {
-      for (String zoneId : zones) {
-         MessageApi messageApi = api.getMessageApiForZoneAndClientAndQueue(zoneId, CLIENT_ID, "jclouds-test");
+      for (String regionId : regions) {
+         MessageApi messageApi = api.getMessageApi(regionId, CLIENT_ID, "jclouds-test");
 
          MessageStream messageStream = messageApi.stream(echo(true));
 
@@ -68,8 +68,8 @@ public class MessageApiLiveTest extends BaseMarconiApiLiveTest {
 
    @Test(dependsOnMethods = { "streamZeroPagesOfMessages" })
    public void createMessage() throws Exception {
-      for (String zoneId : zones) {
-         MessageApi messageApi = api.getMessageApiForZoneAndClientAndQueue(zoneId, CLIENT_ID, "jclouds-test");
+      for (String regionId : regions) {
+         MessageApi messageApi = api.getMessageApi(regionId, CLIENT_ID, "jclouds-test");
 
          String json1 = "{\"event\":{\"name\":\"Edmonton Java User Group\",\"attendees\":[\"bob\",\"jim\",\"sally\"]}}";
          CreateMessage message1 = CreateMessage.builder().ttl(120).body(json1).build();
@@ -84,8 +84,8 @@ public class MessageApiLiveTest extends BaseMarconiApiLiveTest {
 
    @Test(dependsOnMethods = { "createMessage" })
    public void streamOnePageOfMessages() throws Exception {
-      for (String zoneId : zones) {
-         MessageApi messageApi = api.getMessageApiForZoneAndClientAndQueue(zoneId, CLIENT_ID, "jclouds-test");
+      for (String regionId : regions) {
+         MessageApi messageApi = api.getMessageApi(regionId, CLIENT_ID, "jclouds-test");
 
          MessageStream messageStream = messageApi.stream(echo(true));
 
@@ -101,8 +101,8 @@ public class MessageApiLiveTest extends BaseMarconiApiLiveTest {
 
    @Test(dependsOnMethods = { "streamOnePageOfMessages" })
    public void createMessages() throws Exception {
-      for (String zoneId : zones) {
-         MessageApi messageApi = api.getMessageApiForZoneAndClientAndQueue(zoneId, CLIENT_ID, "jclouds-test");
+      for (String regionId : regions) {
+         MessageApi messageApi = api.getMessageApi(regionId, CLIENT_ID, "jclouds-test");
 
          String json1 = "{\"event\":{\"name\":\"Austin Java User Group\",\"attendees\":[\"bob\",\"jim\",\"sally\"]}}";
          CreateMessage message1 = CreateMessage.builder().ttl(120).body(json1).build();
@@ -121,9 +121,9 @@ public class MessageApiLiveTest extends BaseMarconiApiLiveTest {
 
    @Test(dependsOnMethods = { "createMessages" })
    public void streamManyPagesOfMessages() throws Exception {
-      for (String zoneId : zones) {
-         MessageApi messageApi = api.getMessageApiForZoneAndClientAndQueue(zoneId, CLIENT_ID, "jclouds-test");
-         messageIds.put(zoneId, new ArrayList<String>());
+      for (String regionId : regions) {
+         MessageApi messageApi = api.getMessageApi(regionId, CLIENT_ID, "jclouds-test");
+         messageIds.put(regionId, new ArrayList<String>());
 
          MessageStream messageStream = messageApi.stream(echo(true).limit(2));
 
@@ -131,7 +131,7 @@ public class MessageApiLiveTest extends BaseMarconiApiLiveTest {
             assertEquals(Iterables.size(messageStream), 2);
 
             for (Message message : messageStream) {
-               messageIds.get(zoneId).add(message.getId());
+               messageIds.get(regionId).add(message.getId());
             }
 
             messageStream = messageApi.stream(messageStream.nextStreamOptions());
@@ -143,10 +143,10 @@ public class MessageApiLiveTest extends BaseMarconiApiLiveTest {
 
    @Test(dependsOnMethods = { "streamManyPagesOfMessages" })
    public void listMessagesByIds() throws Exception {
-      for (String zoneId : zones) {
-         MessageApi messageApi = api.getMessageApiForZoneAndClientAndQueue(zoneId, CLIENT_ID, "jclouds-test");
+      for (String regionId : regions) {
+         MessageApi messageApi = api.getMessageApi(regionId, CLIENT_ID, "jclouds-test");
 
-         List<Message> messages = messageApi.list(messageIds.get(zoneId));
+         List<Message> messages = messageApi.list(messageIds.get(regionId));
 
          assertEquals(messages.size(), 4);
 
@@ -159,10 +159,10 @@ public class MessageApiLiveTest extends BaseMarconiApiLiveTest {
 
    @Test(dependsOnMethods = { "listMessagesByIds" })
    public void getMessage() throws Exception {
-      for (String zoneId : zones) {
-         MessageApi messageApi = api.getMessageApiForZoneAndClientAndQueue(zoneId, CLIENT_ID, "jclouds-test");
+      for (String regionId : regions) {
+         MessageApi messageApi = api.getMessageApi(regionId, CLIENT_ID, "jclouds-test");
 
-         Message message = messageApi.get(getLast(messageIds.get(zoneId)));
+         Message message = messageApi.get(getLast(messageIds.get(regionId)));
 
          assertNotNull(message.getId());
          assertNotNull(message.getBody());
@@ -171,10 +171,10 @@ public class MessageApiLiveTest extends BaseMarconiApiLiveTest {
 
    @Test(dependsOnMethods = { "getMessage" })
    public void deleteMessagesByClaimId() throws Exception {
-      for (String zoneId : zones) {
+      for (String regionId : regions) {
          UUID clientId = UUID.fromString("3381af92-2b9e-11e3-b191-71861300734c");
-         MessageApi messageApi = api.getMessageApiForZoneAndClientAndQueue(zoneId, CLIENT_ID, "jclouds-test");
-         ClaimApi claimApi = api.getClaimApiForZoneAndClientAndQueue(zoneId, clientId, "jclouds-test");
+         MessageApi messageApi = api.getMessageApi(regionId, CLIENT_ID, "jclouds-test");
+         ClaimApi claimApi = api.getClaimApi(regionId, clientId, "jclouds-test");
          Message message = getOnlyElement(claimApi.claim(300, 100, 1));
 
          boolean success = messageApi.deleteByClaim(message.getId(), message.getClaimId().get());
@@ -185,10 +185,10 @@ public class MessageApiLiveTest extends BaseMarconiApiLiveTest {
 
    @Test(dependsOnMethods = { "deleteMessagesByClaimId" })
    public void deleteMessages() throws Exception {
-      for (String zoneId : zones) {
-         MessageApi messageApi = api.getMessageApiForZoneAndClientAndQueue(zoneId, CLIENT_ID, "jclouds-test");
+      for (String regionId : regions) {
+         MessageApi messageApi = api.getMessageApi(regionId, CLIENT_ID, "jclouds-test");
 
-         boolean success = messageApi.delete(messageIds.get(zoneId));
+         boolean success = messageApi.delete(messageIds.get(regionId));
 
          assertTrue(success);
       }
@@ -196,8 +196,8 @@ public class MessageApiLiveTest extends BaseMarconiApiLiveTest {
 
    @Test(dependsOnMethods = { "deleteMessages" })
    public void delete() throws Exception {
-      for (String zoneId : zones) {
-         QueueApi queueApi = api.getQueueApiForZoneAndClient(zoneId, CLIENT_ID);
+      for (String regionId : regions) {
+         QueueApi queueApi = api.getQueueApi(regionId, CLIENT_ID);
          boolean success = queueApi.delete("jclouds-test");
 
          assertTrue(success);

--- a/openstack-marconi/src/test/java/org/jclouds/openstack/marconi/v1/features/MessageApiMockTest.java
+++ b/openstack-marconi/src/test/java/org/jclouds/openstack/marconi/v1/features/MessageApiMockTest.java
@@ -48,7 +48,7 @@ public class MessageApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
 
       try {
          MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
-         MessageApi messageApi = api.getMessageApiForZoneAndClientAndQueue("DFW", CLIENT_ID, "jclouds-test");
+         MessageApi messageApi = api.getMessageApi("DFW", CLIENT_ID, "jclouds-test");
 
          String json1 = "{\"event\":{\"name\":\"Edmonton Java User Group\",\"attendees\":[\"bob\",\"jim\",\"sally\"]}}";
          CreateMessage createMessage1 = CreateMessage.builder().ttl(120).body(json1).build();
@@ -76,7 +76,7 @@ public class MessageApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
 
       try {
          MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
-         MessageApi messageApi = api.getMessageApiForZoneAndClientAndQueue("DFW", CLIENT_ID, "jclouds-test");
+         MessageApi messageApi = api.getMessageApi("DFW", CLIENT_ID, "jclouds-test");
 
          String json1 = "{\"event\":{\"name\":\"Austin Java User Group\",\"attendees\":[\"bob\",\"jim\",\"sally\"]}}";
          CreateMessage createMessage1 = CreateMessage.builder().ttl(120).body(json1).build();
@@ -110,7 +110,7 @@ public class MessageApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
 
       try {
          MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
-         MessageApi messageApi = api.getMessageApiForZoneAndClientAndQueue("DFW", CLIENT_ID, "jclouds-test");
+         MessageApi messageApi = api.getMessageApi("DFW", CLIENT_ID, "jclouds-test");
 
          MessageStream messageStream = messageApi.stream();
 
@@ -134,7 +134,7 @@ public class MessageApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
 
       try {
          MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
-         MessageApi messageApi = api.getMessageApiForZoneAndClientAndQueue("DFW", CLIENT_ID, "jclouds-test");
+         MessageApi messageApi = api.getMessageApi("DFW", CLIENT_ID, "jclouds-test");
 
          MessageStream messageStream = messageApi.stream();
 
@@ -166,7 +166,7 @@ public class MessageApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
 
       try {
          MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
-         MessageApi messageApi = api.getMessageApiForZoneAndClientAndQueue("DFW", CLIENT_ID, "jclouds-test");
+         MessageApi messageApi = api.getMessageApi("DFW", CLIENT_ID, "jclouds-test");
 
          MessageStream messageStream = messageApi.stream(limit(2));
 
@@ -197,7 +197,7 @@ public class MessageApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
 
       try {
          MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
-         MessageApi messageApi = api.getMessageApiForZoneAndClientAndQueue("DFW", CLIENT_ID, "jclouds-test");
+         MessageApi messageApi = api.getMessageApi("DFW", CLIENT_ID, "jclouds-test");
          List<String> ids = ImmutableList.of("52928896b04a584f24883227", "52928896b04a584f24883228", "52928896b04a584f24883229");
 
          List<Message> messages = messageApi.list(ids);
@@ -227,7 +227,7 @@ public class MessageApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
 
       try {
          MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
-         MessageApi messageApi = api.getMessageApiForZoneAndClientAndQueue("DFW", CLIENT_ID, "jclouds-test");
+         MessageApi messageApi = api.getMessageApi("DFW", CLIENT_ID, "jclouds-test");
 
          Message message = messageApi.get("5292b30cef913e6d026f4dec");
 
@@ -252,7 +252,7 @@ public class MessageApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
 
       try {
          MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
-         MessageApi messageApi = api.getMessageApiForZoneAndClientAndQueue("DFW", CLIENT_ID, "jclouds-test");
+         MessageApi messageApi = api.getMessageApi("DFW", CLIENT_ID, "jclouds-test");
          List<String> ids = ImmutableList.of("52936b8a3ac24e6ef4c067dd", "5292b30cef913e6d026f4dec");
 
          boolean success = messageApi.delete(ids);
@@ -275,7 +275,7 @@ public class MessageApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
 
       try {
          MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
-         MessageApi messageApi = api.getMessageApiForZoneAndClientAndQueue("DFW", CLIENT_ID, "jclouds-test");
+         MessageApi messageApi = api.getMessageApi("DFW", CLIENT_ID, "jclouds-test");
 
          boolean success = messageApi.deleteByClaim("52936b8a3ac24e6ef4c067dd", "5292b30cef913e6d026f4dec");
 

--- a/openstack-marconi/src/test/java/org/jclouds/openstack/marconi/v1/features/QueueApiLiveTest.java
+++ b/openstack-marconi/src/test/java/org/jclouds/openstack/marconi/v1/features/QueueApiLiveTest.java
@@ -40,8 +40,8 @@ public class QueueApiLiveTest extends BaseMarconiApiLiveTest {
    private static final UUID CLIENT_ID = UUID.fromString("3381af92-2b9e-11e3-b191-71861300734c");
 
    public void listZeroPagesOfQueues() throws Exception {
-      for (String zoneId : zones) {
-         QueueApi queueApi = api.getQueueApiForZoneAndClient(zoneId, CLIENT_ID);
+      for (String regionId : regions) {
+         QueueApi queueApi = api.getQueueApi(regionId, CLIENT_ID);
          List<Queue> queues = queueApi.list(false).concat().toList();
 
          assertTrue(queues.isEmpty());
@@ -50,8 +50,8 @@ public class QueueApiLiveTest extends BaseMarconiApiLiveTest {
 
    @Test(dependsOnMethods = { "listZeroPagesOfQueues" })
    public void create() throws Exception {
-      for (String zoneId : zones) {
-         QueueApi queueApi = api.getQueueApiForZoneAndClient(zoneId, CLIENT_ID);
+      for (String regionId : regions) {
+         QueueApi queueApi = api.getQueueApi(regionId, CLIENT_ID);
 
          for (int i = 0; i < 6; i++) {
             boolean success = queueApi.create("jclouds-test-" + i);
@@ -63,8 +63,8 @@ public class QueueApiLiveTest extends BaseMarconiApiLiveTest {
 
    @Test(dependsOnMethods = { "create" })
    public void listOnePageOfQueues() throws Exception {
-      for (String zoneId : zones) {
-         QueueApi queueApi = api.getQueueApiForZoneAndClient(zoneId, CLIENT_ID);
+      for (String regionId : regions) {
+         QueueApi queueApi = api.getQueueApi(regionId, CLIENT_ID);
          List<Queue> queues = queueApi.list(false).concat().toList();
 
          assertEquals(queues.size(), 6);
@@ -78,8 +78,8 @@ public class QueueApiLiveTest extends BaseMarconiApiLiveTest {
 
    @Test(dependsOnMethods = { "listOnePageOfQueues" })
    public void createMore() throws Exception {
-      for (String zoneId : zones) {
-         QueueApi queueApi = api.getQueueApiForZoneAndClient(zoneId, CLIENT_ID);
+      for (String regionId : regions) {
+         QueueApi queueApi = api.getQueueApi(regionId, CLIENT_ID);
 
          for (int i = 6; i < 12; i++) {
             boolean success = queueApi.create("jclouds-test-" + i);
@@ -91,8 +91,8 @@ public class QueueApiLiveTest extends BaseMarconiApiLiveTest {
 
    @Test(dependsOnMethods = { "createMore" })
    public void listManyPagesOfQueues() throws Exception {
-      for (String zoneId : zones) {
-         QueueApi queueApi = api.getQueueApiForZoneAndClient(zoneId, CLIENT_ID);
+      for (String regionId : regions) {
+         QueueApi queueApi = api.getQueueApi(regionId, CLIENT_ID);
          List<Queue> queues = queueApi.list(false).concat().toList();
 
          assertEquals(queues.size(), 12);
@@ -106,8 +106,8 @@ public class QueueApiLiveTest extends BaseMarconiApiLiveTest {
 
    @Test(dependsOnMethods = { "listManyPagesOfQueues" })
    public void listManyPagesOfQueuesManually() throws Exception {
-      for (String zoneId : zones) {
-         QueueApi queueApi = api.getQueueApiForZoneAndClient(zoneId, CLIENT_ID);
+      for (String regionId : regions) {
+         QueueApi queueApi = api.getQueueApi(regionId, CLIENT_ID);
 
          Queues queues = queueApi.list(limit(6));
 
@@ -126,8 +126,8 @@ public class QueueApiLiveTest extends BaseMarconiApiLiveTest {
 
    @Test(dependsOnMethods = { "listManyPagesOfQueuesManually" })
    public void exists() throws Exception {
-      for (String zoneId : zones) {
-         QueueApi queueApi = api.getQueueApiForZoneAndClient(zoneId, CLIENT_ID);
+      for (String regionId : regions) {
+         QueueApi queueApi = api.getQueueApi(regionId, CLIENT_ID);
          boolean success = queueApi.exists("jclouds-test-1");
 
          assertTrue(success);
@@ -136,8 +136,8 @@ public class QueueApiLiveTest extends BaseMarconiApiLiveTest {
 
    @Test(dependsOnMethods = { "exists" })
    public void setMetadata() throws Exception {
-      for (String zoneId : zones) {
-         QueueApi queueApi = api.getQueueApiForZoneAndClient(zoneId, CLIENT_ID);
+      for (String regionId : regions) {
+         QueueApi queueApi = api.getQueueApi(regionId, CLIENT_ID);
          Map<String, String> metadata = ImmutableMap.of("key1", "value1");
          boolean success = queueApi.setMetadata("jclouds-test-1", metadata);
 
@@ -147,8 +147,8 @@ public class QueueApiLiveTest extends BaseMarconiApiLiveTest {
 
    @Test(dependsOnMethods = { "setMetadata" })
    public void listManyPagesOfQueuesWithDetails() throws Exception {
-      for (String zoneId : zones) {
-         QueueApi queueApi = api.getQueueApiForZoneAndClient(zoneId, CLIENT_ID);
+      for (String regionId : regions) {
+         QueueApi queueApi = api.getQueueApi(regionId, CLIENT_ID);
          List<Queue> queues = queueApi.list(true).concat().toList();
 
          assertEquals(queues.size(), 12);
@@ -169,8 +169,8 @@ public class QueueApiLiveTest extends BaseMarconiApiLiveTest {
 
    @Test(dependsOnMethods = { "listManyPagesOfQueuesWithDetails" })
    public void getMetadata() throws Exception {
-      for (String zoneId : zones) {
-         QueueApi queueApi = api.getQueueApiForZoneAndClient(zoneId, CLIENT_ID);
+      for (String regionId : regions) {
+         QueueApi queueApi = api.getQueueApi(regionId, CLIENT_ID);
          Map<String, String> metadata = queueApi.getMetadata("jclouds-test-1");
 
          assertEquals(metadata.get("key1"), "value1");
@@ -179,8 +179,8 @@ public class QueueApiLiveTest extends BaseMarconiApiLiveTest {
 
    @Test(dependsOnMethods = { "getMetadata" })
    public void getStatsWithoutTotal() throws Exception {
-      for (String zoneId : zones) {
-         QueueApi queueApi = api.getQueueApiForZoneAndClient(zoneId, CLIENT_ID);
+      for (String regionId : regions) {
+         QueueApi queueApi = api.getQueueApi(regionId, CLIENT_ID);
          QueueStats stats = queueApi.getStats("jclouds-test-1");
 
          assertEquals(stats.getMessagesStats().getClaimed(), 0);
@@ -193,8 +193,8 @@ public class QueueApiLiveTest extends BaseMarconiApiLiveTest {
 
    @Test(dependsOnMethods = { "getStatsWithoutTotal" })
    public void getStatsWithTotal() throws Exception {
-      for (String zoneId : zones) {
-         MessageApi messageApi = api.getMessageApiForZoneAndClientAndQueue(zoneId, CLIENT_ID, "jclouds-test-1");
+      for (String regionId : regions) {
+         MessageApi messageApi = api.getMessageApi(regionId, CLIENT_ID, "jclouds-test-1");
 
          String json1 = "{\"event\":{\"type\":\"hockey\",\"players\":[\"bob\",\"jim\",\"sally\"]}}";
          CreateMessage message1 = CreateMessage.builder().ttl(120).body(json1).build();
@@ -202,7 +202,7 @@ public class QueueApiLiveTest extends BaseMarconiApiLiveTest {
 
          messageApi.create(message);
 
-         QueueApi queueApi = api.getQueueApiForZoneAndClient(zoneId, CLIENT_ID);
+         QueueApi queueApi = api.getQueueApi(regionId, CLIENT_ID);
          QueueStats stats = queueApi.getStats("jclouds-test-1");
 
          assertEquals(stats.getMessagesStats().getClaimed(), 0);
@@ -217,8 +217,8 @@ public class QueueApiLiveTest extends BaseMarconiApiLiveTest {
 
    @Test(dependsOnMethods = { "getStatsWithTotal" })
    public void delete() throws Exception {
-      for (String zoneId : zones) {
-         QueueApi queueApi = api.getQueueApiForZoneAndClient(zoneId, CLIENT_ID);
+      for (String regionId : regions) {
+         QueueApi queueApi = api.getQueueApi(regionId, CLIENT_ID);
 
          for (int i = 0; i < 12; i++) {
             boolean success = queueApi.delete("jclouds-test-" + i);
@@ -230,8 +230,8 @@ public class QueueApiLiveTest extends BaseMarconiApiLiveTest {
 
    @Test(dependsOnMethods = { "delete" })
    public void doesNotExist() throws Exception {
-      for (String zoneId : zones) {
-         QueueApi queueApi = api.getQueueApiForZoneAndClient(zoneId, CLIENT_ID);
+      for (String regionId : regions) {
+         QueueApi queueApi = api.getQueueApi(regionId, CLIENT_ID);
          boolean success = queueApi.exists("jclouds-test-1");
 
          assertFalse(success);

--- a/openstack-marconi/src/test/java/org/jclouds/openstack/marconi/v1/features/QueueApiMockTest.java
+++ b/openstack-marconi/src/test/java/org/jclouds/openstack/marconi/v1/features/QueueApiMockTest.java
@@ -52,7 +52,7 @@ public class QueueApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
 
       try {
          MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
-         QueueApi queueApi = api.getQueueApiForZoneAndClient("DFW", CLIENT_ID);
+         QueueApi queueApi = api.getQueueApi("DFW", CLIENT_ID);
          boolean success = queueApi.create("jclouds-test");
 
          assertTrue(success);
@@ -73,7 +73,7 @@ public class QueueApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
 
       try {
          MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
-         QueueApi queueApi = api.getQueueApiForZoneAndClient("DFW", CLIENT_ID);
+         QueueApi queueApi = api.getQueueApi("DFW", CLIENT_ID);
          boolean success = queueApi.delete("jclouds-test");
 
          assertTrue(success);
@@ -94,7 +94,7 @@ public class QueueApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
 
       try {
          MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
-         QueueApi queueApi = api.getQueueApiForZoneAndClient("DFW", CLIENT_ID);
+         QueueApi queueApi = api.getQueueApi("DFW", CLIENT_ID);
          boolean success = queueApi.exists("jclouds-test");
 
          assertTrue(success);
@@ -115,7 +115,7 @@ public class QueueApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
 
       try {
          MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
-         QueueApi queueApi = api.getQueueApiForZoneAndClient("DFW", CLIENT_ID);
+         QueueApi queueApi = api.getQueueApi("DFW", CLIENT_ID);
          boolean success = queueApi.exists("jclouds-blerg");
 
          assertFalse(success);
@@ -136,7 +136,7 @@ public class QueueApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
 
       try {
          MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
-         QueueApi queueApi = api.getQueueApiForZoneAndClient("DFW", CLIENT_ID);
+         QueueApi queueApi = api.getQueueApi("DFW", CLIENT_ID);
 
          List<Queue> queues = queueApi.list(false).concat().toList();
 
@@ -159,7 +159,7 @@ public class QueueApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
 
       try {
          MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
-         QueueApi queueApi = api.getQueueApiForZoneAndClient("DFW", CLIENT_ID);
+         QueueApi queueApi = api.getQueueApi("DFW", CLIENT_ID);
 
          List<Queue> queues = queueApi.list(false).concat().toList();
 
@@ -184,7 +184,7 @@ public class QueueApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
 
       try {
          MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
-         QueueApi queueApi = api.getQueueApiForZoneAndClient("DFW", CLIENT_ID);
+         QueueApi queueApi = api.getQueueApi("DFW", CLIENT_ID);
 
          FluentIterable<Queue> queues = queueApi.list(false).concat();
 
@@ -202,7 +202,7 @@ public class QueueApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
 
       try {
          MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
-         QueueApi queueApi = api.getQueueApiForZoneAndClient("DFW", CLIENT_ID);
+         QueueApi queueApi = api.getQueueApi("DFW", CLIENT_ID);
 
          Queues queues = queueApi.list(ListQueuesOptions.NONE);
 
@@ -222,7 +222,7 @@ public class QueueApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
 
       try {
          MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
-         QueueApi queueApi = api.getQueueApiForZoneAndClient("DFW", CLIENT_ID);
+         QueueApi queueApi = api.getQueueApi("DFW", CLIENT_ID);
 
          List<Queue> queues = queueApi.list(false).concat().toList();
 
@@ -253,7 +253,7 @@ public class QueueApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
 
       try {
          MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
-         QueueApi queueApi = api.getQueueApiForZoneAndClient("DFW", CLIENT_ID);
+         QueueApi queueApi = api.getQueueApi("DFW", CLIENT_ID);
 
          Queues queues = queueApi.list(limit(6));
 
@@ -286,7 +286,7 @@ public class QueueApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
 
       try {
          MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
-         QueueApi queueApi = api.getQueueApiForZoneAndClient("DFW", CLIENT_ID);
+         QueueApi queueApi = api.getQueueApi("DFW", CLIENT_ID);
          Map<String, String> metadata = ImmutableMap.of("key1", "value1");
          boolean success = queueApi.setMetadata("jclouds-test", metadata);
 
@@ -310,7 +310,7 @@ public class QueueApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
 
       try {
          MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
-         QueueApi queueApi = api.getQueueApiForZoneAndClient("DFW", CLIENT_ID);
+         QueueApi queueApi = api.getQueueApi("DFW", CLIENT_ID);
          Map<String, String> metadata = queueApi.getMetadata("jclouds-test");
 
          assertEquals(metadata.get("key1"), "value1");
@@ -331,7 +331,7 @@ public class QueueApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
 
       try {
          MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
-         QueueApi queueApi = api.getQueueApiForZoneAndClient("DFW", CLIENT_ID);
+         QueueApi queueApi = api.getQueueApi("DFW", CLIENT_ID);
          QueueStats stats = queueApi.getStats("jclouds-test");
 
          assertEquals(stats.getMessagesStats().getClaimed(), 0);
@@ -356,7 +356,7 @@ public class QueueApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
 
       try {
          MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
-         QueueApi queueApi = api.getQueueApiForZoneAndClient("DFW", CLIENT_ID);
+         QueueApi queueApi = api.getQueueApi("DFW", CLIENT_ID);
          QueueStats stats = queueApi.getStats("jclouds-test");
 
          assertEquals(stats.getMessagesStats().getClaimed(), 0);

--- a/openstack-marconi/src/test/java/org/jclouds/openstack/marconi/v1/internal/BaseMarconiApiLiveTest.java
+++ b/openstack-marconi/src/test/java/org/jclouds/openstack/marconi/v1/internal/BaseMarconiApiLiveTest.java
@@ -27,21 +27,21 @@ import java.util.Set;
 
 public class BaseMarconiApiLiveTest extends BaseApiLiveTest<MarconiApi> {
 
-   protected Set<String> zones = Sets.newHashSet();
+   protected Set<String> regions = Sets.newHashSet();
 
    public BaseMarconiApiLiveTest() {
       provider = "openstack-marconi";
    }
 
    @BeforeClass
-   public void setupZones() {
-      String key = "test." + provider + ".zone";
+   public void setupRegions() {
+      String key = "test." + provider + ".region";
 
       if (System.getProperties().containsKey(key)) {
-         zones.add(System.getProperty(key));
+         regions.add(System.getProperty(key));
       }
       else {
-         zones = api.getConfiguredZones();
+         regions = api.getConfiguredRegions();
       }
    }
 

--- a/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2/NeutronApi.java
+++ b/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2/NeutronApi.java
@@ -70,7 +70,20 @@ public interface NeutronApi extends Closeable {
 
    /**
     * Provides synchronous access to Router features.
+    *
+    * <h3>NOTE</h3>
+    * This API is an extension that may or may not be present in your OpenStack cloud. Use the Optional return type
+    * to determine if it is present.
     */
    @Delegate
+   Optional<? extends RouterApi> getRouterApi(@EndpointParam(parser = RegionToEndpoint.class) @Nullable String region);
+
+   /**
+    * Provides synchronous access to Router features.
+    * @deprecated Please use {@link #getRouterApi(String)} as this method will be removed in jclouds 3.0.
+    */
+   @Deprecated
+   @Delegate
    Optional<? extends RouterApi> getRouterExtensionApi(@EndpointParam(parser = RegionToEndpoint.class) @Nullable String region);
+
 }

--- a/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2/extensions/RouterApi.java
+++ b/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2/extensions/RouterApi.java
@@ -16,8 +16,19 @@
  */
 package org.jclouds.openstack.neutron.v2.extensions;
 
-import com.google.common.annotations.Beta;
-import org.jclouds.Fallbacks;
+import javax.inject.Named;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.MediaType;
+
+import org.jclouds.Fallbacks.EmptyPagedIterableOnNotFoundOr404;
+import org.jclouds.Fallbacks.FalseOnNotFoundOr404;
+import org.jclouds.Fallbacks.NullOnNotFoundOr404;
 import org.jclouds.collect.PagedIterable;
 import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.openstack.keystone.v2_0.filters.AuthenticateRequest;
@@ -38,15 +49,7 @@ import org.jclouds.rest.annotations.SelectJson;
 import org.jclouds.rest.annotations.Transform;
 import org.jclouds.rest.annotations.WrapWith;
 
-import javax.inject.Named;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.core.MediaType;
+import com.google.common.annotations.Beta;
 
 /**
  * Provides synchronous access to Router operations on the OpenStack Neutron API.
@@ -73,7 +76,7 @@ public interface RouterApi {
    @GET
    @Transform(RouterToPagedIterable.class)
    @ResponseParser(ParseRouters.class)
-   @Fallback(Fallbacks.EmptyPagedIterableOnNotFoundOr404.class)
+   @Fallback(EmptyPagedIterableOnNotFoundOr404.class)
    PagedIterable<Router> list();
 
    /**
@@ -95,7 +98,7 @@ public interface RouterApi {
    @GET
    @Path("/{id}")
    @SelectJson("router")
-   @Fallback(Fallbacks.NullOnNotFoundOr404.class)
+   @Fallback(NullOnNotFoundOr404.class)
    @Nullable
    Router get(@PathParam("id") String id);
 
@@ -121,7 +124,7 @@ public interface RouterApi {
    @PUT
    @Path("/{id}")
    @SelectJson("router")
-   @Fallback(Fallbacks.NullOnNotFoundOr404.class)
+   @Fallback(NullOnNotFoundOr404.class)
    @Nullable
    Router update(@PathParam("id") String id, @WrapWith("router") Router.UpdateOptions router);
 
@@ -134,7 +137,7 @@ public interface RouterApi {
    @Named("router:delete")
    @DELETE
    @Path("/{id}")
-   @Fallback(Fallbacks.FalseOnNotFoundOr404.class)
+   @Fallback(FalseOnNotFoundOr404.class)
    boolean delete(@PathParam("id") String id);
 
    /**
@@ -148,7 +151,7 @@ public interface RouterApi {
    @PUT
    @Path("/{id}/add_router_interface")
    @MapBinder(EmptyOptions.class)
-   @Fallback(Fallbacks.NullOnNotFoundOr404.class)
+   @Fallback(NullOnNotFoundOr404.class)
    @Nullable
    RouterInterface addInterfaceForSubnet(@PathParam("id") String routerId, @PayloadParam("subnet_id") String subnetId);
 
@@ -163,7 +166,7 @@ public interface RouterApi {
    @PUT
    @Path("/{id}/add_router_interface")
    @MapBinder(EmptyOptions.class)
-   @Fallback(Fallbacks.NullOnNotFoundOr404.class)
+   @Fallback(NullOnNotFoundOr404.class)
    @Nullable
    RouterInterface addInterfaceForPort(@PathParam("id") String routerId, @PayloadParam("port_id") String portId);
 
@@ -177,7 +180,7 @@ public interface RouterApi {
    @PUT
    @Path("/{id}/remove_router_interface")
    @MapBinder(EmptyOptions.class)
-   @Fallback(Fallbacks.FalseOnNotFoundOr404.class)
+   @Fallback(FalseOnNotFoundOr404.class)
    boolean removeInterfaceForSubnet(@PathParam("id") String routerId, @PayloadParam("subnet_id") String subnetId);
 
    /**
@@ -190,6 +193,6 @@ public interface RouterApi {
    @PUT
    @Path("/{id}/remove_router_interface")
    @MapBinder(EmptyOptions.class)
-   @Fallback(Fallbacks.FalseOnNotFoundOr404.class)
+   @Fallback(FalseOnNotFoundOr404.class)
    boolean removeInterfaceForPort(@PathParam("id") String routerId, @PayloadParam("port_id") String portId);
 }

--- a/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2_0/NeutronApi.java
+++ b/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2_0/NeutronApi.java
@@ -17,10 +17,13 @@
 
 package org.jclouds.openstack.neutron.v2_0;
 
-import com.google.common.base.Optional;
-import com.google.inject.Provides;
+import java.io.Closeable;
+import java.util.Set;
+
 import org.jclouds.javax.annotation.Nullable;
+import org.jclouds.location.Region;
 import org.jclouds.location.Zone;
+import org.jclouds.location.functions.RegionToEndpoint;
 import org.jclouds.location.functions.ZoneToEndpoint;
 import org.jclouds.openstack.neutron.v2_0.extensions.RouterApi;
 import org.jclouds.openstack.neutron.v2_0.features.NetworkApi;
@@ -30,53 +33,104 @@ import org.jclouds.openstack.v2_0.features.ExtensionApi;
 import org.jclouds.rest.annotations.Delegate;
 import org.jclouds.rest.annotations.EndpointParam;
 
-import java.io.Closeable;
-import java.util.Set;
+import com.google.common.base.Optional;
+import com.google.inject.Provides;
 
 /**
  * Provides synchronous access to Neutron.
  * <p/>
  *
- * @see <a href="http://docs.openstack.org/api/openstack-network/2.0/content/">api doc</a>
- * @deprecated Use v2 instead of v2_0
+ * @deprecated Please use {@link org.jclouds.openstack.neutron.v2.NeutronApi} as this
+ *             interface will be removed in jclouds 3.0.
  */
 @Deprecated
 public interface NeutronApi extends Closeable {
+
+   /**
+    * @return the Region codes configured
+    */
+   @Provides
+   @Region
+   Set<String> getConfiguredRegions();
+
+   /**
+    * Provides synchronous access to Extension features.
+    */
+   @Delegate
+   ExtensionApi getExtensionApi(
+           @EndpointParam(parser = RegionToEndpoint.class) @Nullable String region);
+
+   /**
+    * Provides synchronous access to Network features.
+    */
+   @Delegate
+   NetworkApi getNetworkApi(@EndpointParam(parser = RegionToEndpoint.class) @Nullable String region);
+
+   /**
+    * Provides synchronous access to Subnet features
+    */
+   @Delegate
+   SubnetApi getSubnetApi(@EndpointParam(parser = RegionToEndpoint.class) @Nullable String region);
+
+   /**
+    * Provides synchronous access to Port features.
+    */
+   @Delegate
+   PortApi getPortApi(@EndpointParam(parser = RegionToEndpoint.class) @Nullable String region);
+
+   /**
+    * Provides synchronous access to Router features.
+    */
+   @Delegate
+   Optional<? extends RouterApi> getRouterApi(@EndpointParam(parser = RegionToEndpoint.class) @Nullable String region);
+
    /**
     * @return the Zone codes configured
+    * @deprecated Please use {@link #getConfiguredRegions()} as this method will be removed in jclouds 3.0.
     */
+   @Deprecated
    @Provides
    @Zone
    Set<String> getConfiguredZones();
 
    /**
     * Provides synchronous access to Extension features.
+    * @deprecated Please use {@link #getExtensionApi(String)} as this method will be removed in jclouds 3.0.
     */
+   @Deprecated
    @Delegate
    ExtensionApi getExtensionApiForZone(
            @EndpointParam(parser = ZoneToEndpoint.class) @Nullable String zone);
 
    /**
     * Provides synchronous access to Network features.
+    * @deprecated Please use {@link #getNetworkApi(String)} as this method will be removed in jclouds 3.0.
     */
+   @Deprecated
    @Delegate
    NetworkApi getNetworkApiForZone(@EndpointParam(parser = ZoneToEndpoint.class) @Nullable String zone);
 
    /**
-    * Provides synchronous access to Subnet features
+    * Provides synchronous access to Subnet features.
+    * @deprecated Please use {@link #getSubnetApi(String)} as this method will be removed in jclouds 3.0.
     */
+   @Deprecated
    @Delegate
    SubnetApi getSubnetApiForZone(@EndpointParam(parser = ZoneToEndpoint.class) @Nullable String zone);
 
    /**
     * Provides synchronous access to Port features.
+    * @deprecated Please use {@link #getPortApi(String)} as this method will be removed in jclouds 3.0.
     */
+   @Deprecated
    @Delegate
    PortApi getPortApiForZone(@EndpointParam(parser = ZoneToEndpoint.class) @Nullable String zone);
 
    /**
     * Provides synchronous access to Router features.
+    * @deprecated Please use {@link #getRouterApi(String)} as this method will be removed in jclouds 3.0.
     */
+   @Deprecated
    @Delegate
    Optional<? extends RouterApi> getRouterExtensionForZone(@EndpointParam(parser = ZoneToEndpoint.class) @Nullable String zone);
 }

--- a/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2_0/NeutronApiMetadata.java
+++ b/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2_0/NeutronApiMetadata.java
@@ -17,8 +17,12 @@
 
 package org.jclouds.openstack.neutron.v2_0;
 
-import com.google.common.collect.ImmutableSet;
-import com.google.inject.Module;
+import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.CREDENTIAL_TYPE;
+import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.SERVICE_TYPE;
+
+import java.net.URI;
+import java.util.Properties;
+
 import org.jclouds.apis.ApiMetadata;
 import org.jclouds.openstack.keystone.v2_0.config.AuthenticationApiModule;
 import org.jclouds.openstack.keystone.v2_0.config.CredentialTypes;
@@ -28,11 +32,8 @@ import org.jclouds.openstack.neutron.v2_0.config.NeutronHttpApiModule;
 import org.jclouds.openstack.v2_0.ServiceType;
 import org.jclouds.rest.internal.BaseHttpApiMetadata;
 
-import java.net.URI;
-import java.util.Properties;
-
-import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.CREDENTIAL_TYPE;
-import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.SERVICE_TYPE;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Module;
 
 /**
  * Implementation of {@link org.jclouds.apis.ApiMetadata} for Neutron 2.0 API

--- a/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2_0/config/NeutronHttpApiModule.java
+++ b/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2_0/config/NeutronHttpApiModule.java
@@ -16,12 +16,11 @@
  */
 package org.jclouds.openstack.neutron.v2_0.config;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
-import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.Multimap;
-import com.google.inject.Provides;
+import java.net.URI;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import javax.inject.Provider;
+import javax.inject.Singleton;
 import org.jclouds.http.HttpErrorHandler;
 import org.jclouds.http.annotation.ClientError;
 import org.jclouds.http.annotation.Redirection;
@@ -35,27 +34,26 @@ import org.jclouds.openstack.v2_0.functions.PresentWhenExtensionAnnotationNamesp
 import org.jclouds.rest.ConfiguresHttpApi;
 import org.jclouds.rest.config.HttpApiModule;
 import org.jclouds.rest.functions.ImplicitOptionalConverter;
-
-import javax.inject.Provider;
-import javax.inject.Singleton;
-import java.net.URI;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
+import com.google.inject.Provides;
 
 /**
  * Configures the Neutron connection.
  */
-@Deprecated
 @ConfiguresHttpApi
 public class NeutronHttpApiModule extends HttpApiModule<NeutronApi> {
-
+   
    @Override
    protected void configure() {
       bind(DateAdapter.class).to(Iso8601DateAdapter.class);
       bind(ImplicitOptionalConverter.class).to(PresentWhenExtensionAnnotationNamespaceEqualsAnyNamespaceInExtensionsSet.class);
       super.configure();
    }
-
+   
    @Provides
    @Singleton
    public Multimap<URI, URI> aliases() {
@@ -74,7 +72,7 @@ public class NeutronHttpApiModule extends HttpApiModule<NeutronApi> {
                }
             });
    }
-
+   
    @Override
    protected void bindErrorHandlers() {
       bind(HttpErrorHandler.class).annotatedWith(Redirection.class).to(NeutronErrorHandler.class);

--- a/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2_0/extensions/RouterApi.java
+++ b/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2_0/extensions/RouterApi.java
@@ -17,9 +17,20 @@
 
 package org.jclouds.openstack.neutron.v2_0.extensions;
 
+import javax.inject.Named;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.MediaType;
+
 import org.jclouds.Fallbacks;
 import org.jclouds.collect.PagedIterable;
 import org.jclouds.javax.annotation.Nullable;
+import org.jclouds.openstack.keystone.v2_0.KeystoneFallbacks.EmptyPaginatedCollectionOnNotFoundOr404;
 import org.jclouds.openstack.keystone.v2_0.filters.AuthenticateRequest;
 import org.jclouds.openstack.neutron.v2_0.domain.ReferenceWithName;
 import org.jclouds.openstack.neutron.v2_0.domain.Router;
@@ -39,27 +50,14 @@ import org.jclouds.rest.annotations.ResponseParser;
 import org.jclouds.rest.annotations.SelectJson;
 import org.jclouds.rest.annotations.Transform;
 
-import javax.inject.Named;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.core.MediaType;
-
-import static org.jclouds.openstack.keystone.v2_0.KeystoneFallbacks.EmptyPaginatedCollectionOnNotFoundOr404;
-
 /**
  * Provides synchronous access to Router operations on the OpenStack Neutron API.
  * <p/>
  * A logical entity for forwarding packets across internal subnets and NATting them on external
  * networks through an appropriate external gateway.
  *
- * @see <a href=
- *      "http://docs.openstack.org/api/openstack-network/2.0/content/router_ext.html">api doc</a>
- * @deprecated Use v2 instead of v2_0
+ * @deprecated Please use {@link org.jclouds.openstack.neutron.v2.extensions.RouterApi} as this
+ *             interface will be removed in jclouds 3.0.
  */
 @Deprecated
 @Path("/v2.0/routers")

--- a/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2_0/functions/ParseNetworkDetails.java
+++ b/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2_0/functions/ParseNetworkDetails.java
@@ -38,6 +38,9 @@ import java.beans.ConstructorProperties;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+/**
+ * @author Nick Livens
+ */
 @Beta
 @Singleton
 public class ParseNetworkDetails extends ParseJson<Networks> {

--- a/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2_0/functions/ParseNetworks.java
+++ b/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2_0/functions/ParseNetworks.java
@@ -38,6 +38,9 @@ import java.beans.ConstructorProperties;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+/**
+ * @author Nick Livens
+ */
 @Beta
 @Singleton
 public class ParseNetworks extends ParseJson<Networks> {

--- a/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2_0/functions/ParsePortDetails.java
+++ b/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2_0/functions/ParsePortDetails.java
@@ -39,6 +39,9 @@ import java.beans.ConstructorProperties;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+/**
+ * @author Nick Livens
+ */
 @Beta
 @Singleton
 public class ParsePortDetails extends ParseJson<Ports> {

--- a/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2_0/functions/ParsePorts.java
+++ b/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2_0/functions/ParsePorts.java
@@ -38,6 +38,9 @@ import java.beans.ConstructorProperties;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+/**
+ * @author Nick Livens
+ */
 @Beta
 @Singleton
 public class ParsePorts extends ParseJson<Ports> {

--- a/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2_0/functions/ParseRouterDetails.java
+++ b/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2_0/functions/ParseRouterDetails.java
@@ -39,6 +39,9 @@ import java.beans.ConstructorProperties;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.jclouds.openstack.v2_0.options.PaginationOptions.Builder.marker;
 
+/**
+ * @author Nick Livens
+ */
 @Beta
 @Singleton
 public class ParseRouterDetails extends ParseJson<Routers> {

--- a/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2_0/functions/ParseRouters.java
+++ b/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2_0/functions/ParseRouters.java
@@ -39,6 +39,9 @@ import java.beans.ConstructorProperties;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.jclouds.openstack.v2_0.options.PaginationOptions.Builder.marker;
 
+/**
+ * @author Nick Livens
+ */
 @Beta
 @Singleton
 public class ParseRouters extends ParseJson<Routers> {

--- a/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2_0/functions/ParseSubnetDetails.java
+++ b/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2_0/functions/ParseSubnetDetails.java
@@ -38,6 +38,9 @@ import java.beans.ConstructorProperties;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+/**
+ * @author Nick Livens
+ */
 @Beta
 @Singleton
 public class ParseSubnetDetails extends ParseJson<Subnets> {

--- a/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2_0/functions/ParseSubnets.java
+++ b/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2_0/functions/ParseSubnets.java
@@ -38,6 +38,9 @@ import java.beans.ConstructorProperties;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+/**
+ * @author Nick Livens
+ */
 @Beta
 @Singleton
 public class ParseSubnets extends ParseJson<Subnets> {

--- a/openstack-neutron/src/test/java/org/jclouds/openstack/neutron/v2_0/extensions/RouterApiExpectTest.java
+++ b/openstack-neutron/src/test/java/org/jclouds/openstack/neutron/v2_0/extensions/RouterApiExpectTest.java
@@ -42,6 +42,8 @@ import static org.testng.Assert.assertTrue;
 
 /**
  * Tests parsing and Guice wiring of RouterApi
+ *
+ * @author Nick Livens
  */
 @Test(groups = "unit", testName = "RouterApiExpectTest")
 public class RouterApiExpectTest extends BaseNeutronApiExpectTest {

--- a/openstack-neutron/src/test/java/org/jclouds/openstack/neutron/v2_0/extensions/RouterApiLiveTest.java
+++ b/openstack-neutron/src/test/java/org/jclouds/openstack/neutron/v2_0/extensions/RouterApiLiveTest.java
@@ -42,6 +42,8 @@ import static org.testng.Assert.assertTrue;
 
 /**
  * Tests parsing and Guice wiring of RouterApi
+ *
+ * @author Nick Livens
  */
 @Test(groups = "live", testName = "RouterApiLiveTest")
 public class RouterApiLiveTest extends BaseNeutronApiLiveTest {

--- a/openstack-neutron/src/test/java/org/jclouds/openstack/neutron/v2_0/features/NetworkApiExpectTest.java
+++ b/openstack-neutron/src/test/java/org/jclouds/openstack/neutron/v2_0/features/NetworkApiExpectTest.java
@@ -42,6 +42,8 @@ import static org.testng.Assert.assertTrue;
 
 /**
  * Tests parsing and Guice wiring of NetworkApi
+ *
+ * @author Nick Livens
  */
 @Test(groups = "unit", testName = "NetworkApiExpectTest")
 public class NetworkApiExpectTest extends BaseNeutronApiExpectTest {

--- a/openstack-neutron/src/test/java/org/jclouds/openstack/neutron/v2_0/features/NetworkApiLiveTest.java
+++ b/openstack-neutron/src/test/java/org/jclouds/openstack/neutron/v2_0/features/NetworkApiLiveTest.java
@@ -38,6 +38,8 @@ import static org.testng.Assert.assertTrue;
 
 /**
  * Tests parsing and Guice wiring of NetworkApi
+ *
+ * @author Nick Livens
  */
 @Test(groups = "live", testName = "NetworkApiLiveTest")
 public class NetworkApiLiveTest extends BaseNeutronApiLiveTest {

--- a/openstack-neutron/src/test/java/org/jclouds/openstack/neutron/v2_0/features/PortApiExpectTest.java
+++ b/openstack-neutron/src/test/java/org/jclouds/openstack/neutron/v2_0/features/PortApiExpectTest.java
@@ -41,6 +41,8 @@ import static org.testng.Assert.assertTrue;
 
 /**
  * Tests parsing and Guice wiring of PortApi
+ *
+ * @author Nick Livens
  */
 @Test(groups = "unit", testName = "PortApiExpectTest")
 public class PortApiExpectTest extends BaseNeutronApiExpectTest {

--- a/openstack-neutron/src/test/java/org/jclouds/openstack/neutron/v2_0/features/PortApiLiveTest.java
+++ b/openstack-neutron/src/test/java/org/jclouds/openstack/neutron/v2_0/features/PortApiLiveTest.java
@@ -43,6 +43,8 @@ import com.google.common.collect.Sets;
 
 /**
  * Tests PortApi in combination with the Network & SubnetApi
+ *
+ * @author Nick Livens
  */
 @Test(groups = "live", testName = "PortApiLiveTest")
 public class PortApiLiveTest extends BaseNeutronApiLiveTest {

--- a/openstack-neutron/src/test/java/org/jclouds/openstack/neutron/v2_0/features/SubnetApiExpectTest.java
+++ b/openstack-neutron/src/test/java/org/jclouds/openstack/neutron/v2_0/features/SubnetApiExpectTest.java
@@ -40,6 +40,8 @@ import static org.testng.Assert.assertTrue;
 
 /**
  * Tests parsing and Guice wiring of SubnetApi
+ *
+ * @author Nick Livens
  */
 @Test(groups = "unit", testName = "SubnetApiExpectTest")
 public class SubnetApiExpectTest extends BaseNeutronApiExpectTest {

--- a/openstack-neutron/src/test/java/org/jclouds/openstack/neutron/v2_0/features/SubnetApiLiveTest.java
+++ b/openstack-neutron/src/test/java/org/jclouds/openstack/neutron/v2_0/features/SubnetApiLiveTest.java
@@ -43,6 +43,8 @@ import com.google.common.collect.Sets;
 
 /**
  * Tests subnet api in combination with the network api
+ *
+ * @author Nick Livens
  */
 @Test(groups = "live", testName = "SubnetApiLiveTest")
 public class SubnetApiLiveTest extends BaseNeutronApiLiveTest {

--- a/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/SwiftApi.java
+++ b/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/SwiftApi.java
@@ -41,10 +41,7 @@ import com.google.inject.Provides;
  * <p/>
  * OpenStack Object Storage is an object-based storage system that stores content and metadata
  * as objects. You create, modify, and get objects and metadata using this API.
- * <p/>
- * This API is new to jclouds and hence is in Beta. That means we need people to use it and give us feedback. Based
- * on that feedback, minor changes to the interfaces may happen. This code will replace
- * {@code org.jclouds.openstack.swift.SwiftClient} in jclouds 2.0 and it is recommended you adopt it sooner than later.
+ * <p/>8
  */
 @Beta
 public interface SwiftApi extends Closeable {
@@ -54,73 +51,57 @@ public interface SwiftApi extends Closeable {
    Set<String> getConfiguredRegions();
 
    @Delegate
+   AccountApi getAccountApi(@EndpointParam(parser = RegionToEndpoint.class) @Nullable String region);
+
+   @Delegate
+   BulkApi getBulkApi(@EndpointParam(parser = RegionToEndpoint.class) @Nullable String region);
+
+   @Delegate
+   ContainerApi getContainerApi(@EndpointParam(parser = RegionToEndpoint.class) @Nullable String region);
+
+   @Delegate
+   @Path("/{containerName}")
+   ObjectApi getObjectApiForContainer(@EndpointParam(parser = RegionToEndpoint.class) @Nullable String region,
+         @PathParam("containerName") String containerName);
+
+   @Delegate
+   @Path("/{containerName}")
+   StaticLargeObjectApi getStaticLargeObjectApiForContainer(
+         @EndpointParam(parser = RegionToEndpoint.class) @Nullable String region,
+         @PathParam("containerName") String containerName);
+
+   /**
+    * @deprecated Please use {@link #getAccountApi(String)} as this method will be removed in jclouds 2.0.
+    */
+   @Delegate
    AccountApi getAccountApiForRegion(@EndpointParam(parser = RegionToEndpoint.class) @Nullable String region);
 
+   /**
+    * @deprecated Please use {@link #getBulkApi(String)} as this method will be removed in jclouds 2.0.
+    */
    @Delegate
    BulkApi getBulkApiForRegion(@EndpointParam(parser = RegionToEndpoint.class) @Nullable String region);
 
+   /**
+    * @deprecated Please use {@link #getContainerApi(String)} as this method will be removed in jclouds 2.0.
+    */
    @Delegate
    ContainerApi getContainerApiForRegion(@EndpointParam(parser = RegionToEndpoint.class) @Nullable String region);
 
+   /**
+    * @deprecated Please use {@link #getObjectApiForContainer(String)} as this method will be removed in jclouds 2.0.
+    */
    @Delegate
    @Path("/{containerName}")
    ObjectApi getObjectApiForRegionAndContainer(@EndpointParam(parser = RegionToEndpoint.class) @Nullable String region,
          @PathParam("containerName") String containerName);
 
+   /**
+    * @deprecated Please use {@link #getStaticLargeObjectApiForContainer(String)} as this method will be removed in jclouds 2.0.
+    */
    @Delegate
    @Path("/{containerName}")
    StaticLargeObjectApi getStaticLargeObjectApiForRegionAndContainer(
-         @EndpointParam(parser = RegionToEndpoint.class) @Nullable String region,
-         @PathParam("containerName") String containerName);
-
-   /**
-    * @deprecated Please use {@link #getConfiguredRegions()} as this method will be removed in jclouds 1.8.
-    */
-   @Deprecated
-   @Provides
-   @Region
-   Set<String> configuredRegions();
-
-   /**
-    * @deprecated Please use {@link #getAccountApiForRegion(String)} as this method will be removed in jclouds 1.8.
-    */
-   @Deprecated
-   @Delegate
-   AccountApi accountApiInRegion(@EndpointParam(parser = RegionToEndpoint.class) @Nullable String region);
-
-   /**
-    * @deprecated Please use {@link #getBulkApiForRegion(String)} as this method will be removed in jclouds 1.8.
-    */
-   @Deprecated
-   @Delegate
-   BulkApi bulkApiInRegion(@EndpointParam(parser = RegionToEndpoint.class) @Nullable String region);
-
-   /**
-    * @deprecated Please use {@link #getContainerApiForRegion(String)} as this method will be removed in
-    *             jclouds 1.8.
-    */
-   @Deprecated
-   @Delegate
-   ContainerApi containerApiInRegion(@EndpointParam(parser = RegionToEndpoint.class) @Nullable String region);
-
-   /**
-    * @deprecated Please use {@link #getObjectApiForRegionAndContainer(String, String)} as this method will be
-    *             removed in jclouds 1.8.
-    */
-   @Deprecated
-   @Delegate
-   @Path("/{containerName}")
-   ObjectApi objectApiInRegionForContainer(@EndpointParam(parser = RegionToEndpoint.class) @Nullable String region,
-         @PathParam("containerName") String containerName);
-
-   /**
-    * @deprecated Please use {@link #getStaticLargeObjectApiForRegionAndContainer(String, String)} as this method
-    *             will be removed in jclouds 1.8.
-    */
-   @Deprecated
-   @Delegate
-   @Path("/{containerName}")
-   StaticLargeObjectApi staticLargeObjectApiInRegionForContainer(
          @EndpointParam(parser = RegionToEndpoint.class) @Nullable String region,
          @PathParam("containerName") String containerName);
 }

--- a/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/TemporaryUrlSignerMockTest.java
+++ b/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/TemporaryUrlSignerMockTest.java
@@ -41,7 +41,7 @@ public class TemporaryUrlSignerMockTest extends BaseOpenStackMockTest<SwiftApi> 
 
       try {
          SwiftApi api = api(server.getUrl("/").toString(), "openstack-swift");
-         String signature = TemporaryUrlSigner.checkApiEvery(api.getAccountApiForRegion("DFW"), 10000)
+         String signature = TemporaryUrlSigner.checkApiEvery(api.getAccountApi("DFW"), 10000)
                .sign("GET", "/v1/AUTH_account/container/object", 1323479485l);
 
          assertEquals(signature, "d9fc2067e52b06598421664cf6610bfc8fc431f6");
@@ -63,7 +63,7 @@ public class TemporaryUrlSignerMockTest extends BaseOpenStackMockTest<SwiftApi> 
 
       try {
          SwiftApi api = api(server.getUrl("/").toString(), "openstack-swift");
-         TemporaryUrlSigner.checkApiEvery(api.accountApiInRegion("DFW"), 10000)
+         TemporaryUrlSigner.checkApiEvery(api.getAccountApi("DFW"), 10000)
             .sign("GET", "/v1/AUTH_account/container/object", 1323479485l);
       } finally {
          assertEquals(server.getRequestCount(), 2);

--- a/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/features/AccountApiLiveTest.java
+++ b/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/features/AccountApiLiveTest.java
@@ -35,8 +35,8 @@ import com.google.common.collect.ImmutableMap;
 public class AccountApiLiveTest extends BaseSwiftApiLiveTest<SwiftApi> {
 
    public void testGet() throws Exception {
-      for (String regionId : regions) {
-         AccountApi accountApi = api.getAccountApiForRegion(regionId);
+      for (String region : regions) {
+         AccountApi accountApi = api.getAccountApi(region);
          Account account = accountApi.get();
 
          assertNotNull(account);
@@ -47,8 +47,8 @@ public class AccountApiLiveTest extends BaseSwiftApiLiveTest<SwiftApi> {
    }
 
    public void testUpdateMetadata() throws Exception {
-      for (String regionId : regions) {
-         AccountApi accountApi = api.getAccountApiForRegion(regionId);
+      for (String region : regions) {
+         AccountApi accountApi = api.getAccountApi(region);
 
          Map<String, String> meta = ImmutableMap.of("MyAdd1", "foo", "MyAdd2", "bar");
 
@@ -59,8 +59,8 @@ public class AccountApiLiveTest extends BaseSwiftApiLiveTest<SwiftApi> {
    }
 
    public void testDeleteMetadata() throws Exception {
-      for (String regionId : regions) {
-         AccountApi accountApi = api.getAccountApiForRegion(regionId);
+      for (String region : regions) {
+         AccountApi accountApi = api.getAccountApi(region);
 
          Map<String, String> meta = ImmutableMap.of("MyDelete1", "foo", "MyDelete2", "bar");
 

--- a/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/internal/BaseSwiftApiLiveTest.java
+++ b/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/internal/BaseSwiftApiLiveTest.java
@@ -43,7 +43,7 @@ import com.google.common.util.concurrent.Uninterruptibles;
 public abstract class BaseSwiftApiLiveTest<A extends SwiftApi> extends BaseApiLiveTest<A> {
 
    protected Set<String> regions;
-   
+
    protected BaseSwiftApiLiveTest() {
       provider = "openstack-swift";
    }
@@ -70,8 +70,8 @@ public abstract class BaseSwiftApiLiveTest<A extends SwiftApi> extends BaseApiLi
 
    protected void deleteAllObjectsInContainer(String regionId, final String containerName) {
       Uninterruptibles.sleepUninterruptibly(10, TimeUnit.SECONDS);
-      
-      ObjectList objects = api.getObjectApiForRegionAndContainer(regionId, containerName).list(new ListContainerOptions());
+
+      ObjectList objects = api.getObjectApiForContainer(regionId, containerName).list(new ListContainerOptions());
       if (objects == null) {
          return;
       }
@@ -81,7 +81,7 @@ public abstract class BaseSwiftApiLiveTest<A extends SwiftApi> extends BaseApiLi
          }
       });
       if (!pathsToDelete.isEmpty()) {
-         BulkDeleteResponse response = api.getBulkApiForRegion(regionId).bulkDelete(pathsToDelete);
+         BulkDeleteResponse response = api.getBulkApi(regionId).bulkDelete(pathsToDelete);
          checkState(response.getErrors().isEmpty(), "Errors deleting paths %s: %s", pathsToDelete, response);
       }
    }

--- a/rackspace-autoscale-uk/src/main/java/org/jclouds/rackspace/autoscale/uk/AutoscaleUKProviderMetadata.java
+++ b/rackspace-autoscale-uk/src/main/java/org/jclouds/rackspace/autoscale/uk/AutoscaleUKProviderMetadata.java
@@ -17,15 +17,15 @@
 package org.jclouds.rackspace.autoscale.uk;
 
 import static org.jclouds.location.reference.LocationConstants.ISO3166_CODES;
-import static org.jclouds.location.reference.LocationConstants.PROPERTY_ZONE;
-import static org.jclouds.location.reference.LocationConstants.PROPERTY_ZONES;
+import static org.jclouds.location.reference.LocationConstants.PROPERTY_REGION;
+import static org.jclouds.location.reference.LocationConstants.PROPERTY_REGIONS;
 import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.CREDENTIAL_TYPE;
 import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.SERVICE_TYPE;
 
 import java.net.URI;
 import java.util.Properties;
 
-import org.jclouds.openstack.keystone.v2_0.config.KeystoneAuthenticationModule.ZoneModule;
+import org.jclouds.openstack.keystone.v2_0.config.KeystoneAuthenticationModule.RegionModule;
 import org.jclouds.providers.ProviderMetadata;
 import org.jclouds.providers.internal.BaseProviderMetadata;
 import org.jclouds.rackspace.autoscale.v1.AutoscaleApiMetadata;
@@ -64,10 +64,10 @@ public class AutoscaleUKProviderMetadata extends BaseProviderMetadata {
    public static Properties defaultProperties() {
       Properties properties = new Properties();
       properties.setProperty(CREDENTIAL_TYPE, CloudIdentityCredentialTypes.API_KEY_CREDENTIALS);
-      properties.setProperty(SERVICE_TYPE, ServiceType.AUTO_SCALE); 
+      properties.setProperty(SERVICE_TYPE, ServiceType.AUTO_SCALE);
 
-      properties.setProperty(PROPERTY_ZONES, "LON");
-      properties.setProperty(PROPERTY_ZONE + ".LON." + ISO3166_CODES, "GB-SLG");
+      properties.setProperty(PROPERTY_REGIONS, "LON");
+      properties.setProperty(PROPERTY_REGION + ".LON." + ISO3166_CODES, "GB-SLG");
       return properties;
    }
 
@@ -86,7 +86,7 @@ public class AutoscaleUKProviderMetadata extends BaseProviderMetadata {
                .defaultModules(ImmutableSet.<Class<? extends Module>>builder()
                      .add(CloudIdentityAuthenticationApiModule.class)
                      .add(CloudIdentityAuthenticationModule.class)
-                     .add(ZoneModule.class)
+                     .add(RegionModule.class)
                      .add(AutoscaleParserModule.class)
                      .add(AutoscaleHttpApiModule.class)
                      .build())

--- a/rackspace-autoscale-uk/src/test/java/org/jclouds/rackspace/autoscale/uk/AutoscaleUKProviderMetadataExpectTest.java
+++ b/rackspace-autoscale-uk/src/test/java/org/jclouds/rackspace/autoscale/uk/AutoscaleUKProviderMetadataExpectTest.java
@@ -28,7 +28,7 @@ import com.google.common.collect.ImmutableSet;
 
 /**
  * This test ensures that the wiring in {@link AutoscaleUKProviderMetadata} is correct.
- * 
+ *
  */
 @Test(groups = "unit", testName = "AutoscaleUKProviderMetadataExpectTest")
 public class AutoscaleUKProviderMetadataExpectTest extends BaseAutoscaleApiExpectTest {
@@ -39,7 +39,7 @@ public class AutoscaleUKProviderMetadataExpectTest extends BaseAutoscaleApiExpec
       this.credential = "myApiKey";
    }
 
-   public void testCanGetConfiguredZones() {
+   public void testCanGetConfiguredRegions() {
 
       HttpRequest authenticate = HttpRequest.builder().method("POST")
             .endpoint("https://lon.identity.api.rackspacecloud.com/v2.0/tokens")
@@ -55,7 +55,7 @@ public class AutoscaleUKProviderMetadataExpectTest extends BaseAutoscaleApiExpec
 
       AutoscaleApi whenNovaRegionExists = requestSendsResponse(authenticate, authenticationResponse);
 
-      assertEquals(whenNovaRegionExists.getConfiguredZones(), ImmutableSet.of("LON"));
+      assertEquals(whenNovaRegionExists.getConfiguredRegions(), ImmutableSet.of("LON"));
 
    }
 

--- a/rackspace-autoscale-us/src/main/java/org/jclouds/rackspace/autoscale/us/AutoscaleUSProviderMetadata.java
+++ b/rackspace-autoscale-us/src/main/java/org/jclouds/rackspace/autoscale/us/AutoscaleUSProviderMetadata.java
@@ -17,15 +17,15 @@
 package org.jclouds.rackspace.autoscale.us;
 
 import static org.jclouds.location.reference.LocationConstants.ISO3166_CODES;
-import static org.jclouds.location.reference.LocationConstants.PROPERTY_ZONE;
-import static org.jclouds.location.reference.LocationConstants.PROPERTY_ZONES;
+import static org.jclouds.location.reference.LocationConstants.PROPERTY_REGION;
+import static org.jclouds.location.reference.LocationConstants.PROPERTY_REGIONS;
 import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.CREDENTIAL_TYPE;
 import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.SERVICE_TYPE;
 
 import java.net.URI;
 import java.util.Properties;
 
-import org.jclouds.openstack.keystone.v2_0.config.KeystoneAuthenticationModule.ZoneModule;
+import org.jclouds.openstack.keystone.v2_0.config.KeystoneAuthenticationModule.RegionModule;
 import org.jclouds.providers.ProviderMetadata;
 import org.jclouds.providers.internal.BaseProviderMetadata;
 import org.jclouds.rackspace.autoscale.v1.AutoscaleApiMetadata;
@@ -64,14 +64,14 @@ public class AutoscaleUSProviderMetadata extends BaseProviderMetadata {
    public static Properties defaultProperties() {
       Properties properties = new Properties();
       properties.setProperty(CREDENTIAL_TYPE, CloudIdentityCredentialTypes.API_KEY_CREDENTIALS);
-      properties.setProperty(SERVICE_TYPE, ServiceType.AUTO_SCALE); 
+      properties.setProperty(SERVICE_TYPE, ServiceType.AUTO_SCALE);
 
-      properties.setProperty(PROPERTY_ZONES, "ORD,DFW,IAD,SYD,HKG");
-      properties.setProperty(PROPERTY_ZONE + ".ORD." + ISO3166_CODES, "US-IL");
-      properties.setProperty(PROPERTY_ZONE + ".DFW." + ISO3166_CODES, "US-TX");
-      properties.setProperty(PROPERTY_ZONE + ".IAD." + ISO3166_CODES, "US-VA");
-      properties.setProperty(PROPERTY_ZONE + ".SYD." + ISO3166_CODES, "AU-NSW");
-      properties.setProperty(PROPERTY_ZONE + ".HKG." + ISO3166_CODES, "HK");
+      properties.setProperty(PROPERTY_REGIONS, "ORD,DFW,IAD,SYD,HKG");
+      properties.setProperty(PROPERTY_REGION + ".ORD." + ISO3166_CODES, "US-IL");
+      properties.setProperty(PROPERTY_REGION + ".DFW." + ISO3166_CODES, "US-TX");
+      properties.setProperty(PROPERTY_REGION + ".IAD." + ISO3166_CODES, "US-VA");
+      properties.setProperty(PROPERTY_REGION + ".SYD." + ISO3166_CODES, "AU-NSW");
+      properties.setProperty(PROPERTY_REGION + ".HKG." + ISO3166_CODES, "HK");
 
       return properties;
    }
@@ -91,7 +91,7 @@ public class AutoscaleUSProviderMetadata extends BaseProviderMetadata {
                .defaultModules(ImmutableSet.<Class<? extends Module>>builder()
                      .add(CloudIdentityAuthenticationApiModule.class)
                      .add(CloudIdentityAuthenticationModule.class)
-                     .add(ZoneModule.class)
+                     .add(RegionModule.class)
                      .add(AutoscaleParserModule.class)
                      .add(AutoscaleHttpApiModule.class)
                      .build())

--- a/rackspace-autoscale-us/src/main/java/org/jclouds/rackspace/autoscale/us/v1/AutoscaleUSProviderMetadata.java
+++ b/rackspace-autoscale-us/src/main/java/org/jclouds/rackspace/autoscale/us/v1/AutoscaleUSProviderMetadata.java
@@ -17,15 +17,15 @@
 package org.jclouds.rackspace.autoscale.us.v1;
 
 import static org.jclouds.location.reference.LocationConstants.ISO3166_CODES;
-import static org.jclouds.location.reference.LocationConstants.PROPERTY_ZONE;
-import static org.jclouds.location.reference.LocationConstants.PROPERTY_ZONES;
+import static org.jclouds.location.reference.LocationConstants.PROPERTY_REGION;
+import static org.jclouds.location.reference.LocationConstants.PROPERTY_REGIONS;
 import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.CREDENTIAL_TYPE;
 import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.SERVICE_TYPE;
 
 import java.net.URI;
 import java.util.Properties;
 
-import org.jclouds.openstack.keystone.v2_0.config.KeystoneAuthenticationModule.ZoneModule;
+import org.jclouds.openstack.keystone.v2_0.config.KeystoneAuthenticationModule.RegionModule;
 import org.jclouds.providers.ProviderMetadata;
 import org.jclouds.providers.internal.BaseProviderMetadata;
 import org.jclouds.rackspace.autoscale.v1.AutoscaleApiMetadata;
@@ -70,12 +70,12 @@ public class AutoscaleUSProviderMetadata extends BaseProviderMetadata {
       properties.setProperty(CREDENTIAL_TYPE, CloudIdentityCredentialTypes.API_KEY_CREDENTIALS);
       properties.setProperty(SERVICE_TYPE, ServiceType.AUTO_SCALE);
 
-      properties.setProperty(PROPERTY_ZONES, "ORD,DFW,IAD,SYD,HKG");
-      properties.setProperty(PROPERTY_ZONE + ".ORD." + ISO3166_CODES, "US-IL");
-      properties.setProperty(PROPERTY_ZONE + ".DFW." + ISO3166_CODES, "US-TX");
-      properties.setProperty(PROPERTY_ZONE + ".IAD." + ISO3166_CODES, "US-VA");
-      properties.setProperty(PROPERTY_ZONE + ".SYD." + ISO3166_CODES, "AU-NSW");
-      properties.setProperty(PROPERTY_ZONE + ".HKG." + ISO3166_CODES, "HK");
+      properties.setProperty(PROPERTY_REGIONS, "ORD,DFW,IAD,SYD,HKG");
+      properties.setProperty(PROPERTY_REGION + ".ORD." + ISO3166_CODES, "US-IL");
+      properties.setProperty(PROPERTY_REGION + ".DFW." + ISO3166_CODES, "US-TX");
+      properties.setProperty(PROPERTY_REGION + ".IAD." + ISO3166_CODES, "US-VA");
+      properties.setProperty(PROPERTY_REGION + ".SYD." + ISO3166_CODES, "AU-NSW");
+      properties.setProperty(PROPERTY_REGION + ".HKG." + ISO3166_CODES, "HK");
 
       return properties;
    }
@@ -95,7 +95,7 @@ public class AutoscaleUSProviderMetadata extends BaseProviderMetadata {
                .defaultModules(ImmutableSet.<Class<? extends Module>>builder()
                      .add(CloudIdentityAuthenticationApiModule.class)
                      .add(CloudIdentityAuthenticationModule.class)
-                     .add(ZoneModule.class)
+                     .add(RegionModule.class)
                      .add(AutoscaleParserModule.class)
                      .add(AutoscaleHttpApiModule.class)
                      .build())

--- a/rackspace-autoscale-us/src/test/java/org/jclouds/rackspace/autoscale/us/v1/AutoscaleUSProviderMetadataExpectTest.java
+++ b/rackspace-autoscale-us/src/test/java/org/jclouds/rackspace/autoscale/us/v1/AutoscaleUSProviderMetadataExpectTest.java
@@ -53,10 +53,9 @@ public class AutoscaleUSProviderMetadataExpectTest extends BaseAutoscaleApiExpec
             .payload(payloadFromResourceWithContentType("/access_rax_us.json", "application/json"))
             .build();
 
-      AutoscaleApi whenNovaRegionExists = requestSendsResponse(authenticate, authenticationResponse);
+      AutoscaleApi whenAutoscaleRegionExists = requestSendsResponse(authenticate, authenticationResponse);
 
-      assertEquals(whenNovaRegionExists.getConfiguredZones(), ImmutableSet.of("DFW", "ORD", "IAD"));
-
+      assertEquals(whenAutoscaleRegionExists.getConfiguredRegions(), ImmutableSet.of("DFW", "ORD", "IAD"));
    }
 
 }

--- a/rackspace-autoscale/src/main/java/org/jclouds/rackspace/autoscale/v1/AutoscaleApi.java
+++ b/rackspace-autoscale/src/main/java/org/jclouds/rackspace/autoscale/v1/AutoscaleApi.java
@@ -23,8 +23,8 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 
 import org.jclouds.javax.annotation.Nullable;
-import org.jclouds.location.Zone;
-import org.jclouds.location.functions.ZoneToEndpoint;
+import org.jclouds.location.Region;
+import org.jclouds.location.functions.RegionToEndpoint;
 import org.jclouds.openstack.keystone.v2_0.domain.Tenant;
 import org.jclouds.rackspace.autoscale.v1.features.GroupApi;
 import org.jclouds.rackspace.autoscale.v1.features.PolicyApi;
@@ -36,33 +36,32 @@ import com.google.common.base.Optional;
 import com.google.inject.Provides;
 
 /**
- * Provides access to Rackspace Autoscale.
- *  
- * @see <a href="https://rackspace-autoscale.readthedocs.org">API Doc</a>
- * @see <a href="http://docs.autoscale.apiary.io/">Apiary API Doc</a>
+ * Provides access to Rackspace Auto Scale v1 API.
+ *
  */
-public interface AutoscaleApi extends Closeable{
+public interface AutoscaleApi extends Closeable {
    /**
-    * Provides a set of all zones available.
-    * 
-    * @return the Zone codes configured
+    * Provides a set of all regions available.
+    *
+    * @return the Region codes configured
     */
    @Provides
-   @Zone
-   Set<String> getConfiguredZones();
+   @Region
+   Set<String> getConfiguredRegions();
 
    /**
     * Provides access to all scaling Group features.
     */
    @Delegate
-   GroupApi getGroupApiForZone(@EndpointParam(parser = ZoneToEndpoint.class) @Nullable String zone);
+   GroupApi getGroupApi(@EndpointParam(parser = RegionToEndpoint.class) @Nullable String region);
+
 
    /**
     * Provides access to all policy features for scaling Groups.
     */
    @Delegate
    @Path("/groups/{groupId}")
-   PolicyApi getPolicyApiForZoneAndGroup(@EndpointParam(parser = ZoneToEndpoint.class) @Nullable String zone,
+   PolicyApi getPolicyApi(@EndpointParam(parser = RegionToEndpoint.class) @Nullable String region,
          @PathParam("groupId") String groupId);
 
    /**
@@ -70,13 +69,46 @@ public interface AutoscaleApi extends Closeable{
     */
    @Delegate
    @Path("/groups/{groupId}/policies/{policyId}")
-   WebhookApi getWebhookApiForZoneAndGroupAndPolicy(@EndpointParam(parser = ZoneToEndpoint.class) @Nullable String zone,
+   WebhookApi getWebhookApi(@EndpointParam(parser = RegionToEndpoint.class) @Nullable String region,
          @PathParam("groupId") String groupId,
          @PathParam("policyId") String policyId);
 
    /**
     * Provides the Tenant.
     */
-   @Provides 
+   @Provides
    Optional<Tenant> getCurrentTenantId();
+
+   /**
+    * @return the configured zone codes
+    * @deprecated Please use {@link #getConfiguredRegions()} as this method will be removed in jclouds 3.0.
+    */
+   @Deprecated
+   @Provides
+   @Region
+   Set<String> getConfiguredZones();
+
+   /**
+    * Provides access to all policy features for scaling Groups.
+    * @deprecated Please use {@link #getPolicyApi(String, String)} as this method will be removed
+    *             in jclouds 3.0.
+    */
+   @Deprecated
+   @Delegate
+   @Path("/groups/{groupId}")
+   PolicyApi getPolicyApiForGroup(@EndpointParam(parser = RegionToEndpoint.class) @Nullable String region,
+         @PathParam("groupId") String groupId);
+
+   /**
+    * Provides access to webhook management features.
+    * @deprecated Please use {@link #getWebhookApi(String, String, String)} as this method will be removed
+    *             in jclouds 3.0.
+    */
+   @Deprecated
+   @Delegate
+   @Path("/groups/{groupId}/policies/{policyId}")
+   WebhookApi getWebhookApiForGroupAndPolicy(@EndpointParam(parser = RegionToEndpoint.class) @Nullable String region,
+         @PathParam("groupId") String groupId,
+         @PathParam("policyId") String policyId);
+
 }

--- a/rackspace-autoscale/src/main/java/org/jclouds/rackspace/autoscale/v1/AutoscaleApiMetadata.java
+++ b/rackspace-autoscale/src/main/java/org/jclouds/rackspace/autoscale/v1/AutoscaleApiMetadata.java
@@ -23,7 +23,7 @@ import java.net.URI;
 import java.util.Properties;
 
 import org.jclouds.openstack.keystone.v2_0.config.CredentialTypes;
-import org.jclouds.openstack.keystone.v2_0.config.KeystoneAuthenticationModule.ZoneModule;
+import org.jclouds.openstack.keystone.v2_0.config.KeystoneAuthenticationModule.RegionModule;
 import org.jclouds.rackspace.autoscale.v1.config.AutoscaleHttpApiModule;
 import org.jclouds.rackspace.autoscale.v1.config.AutoscaleParserModule;
 import org.jclouds.rackspace.cloudidentity.v2_0.ServiceType;
@@ -35,8 +35,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.inject.Module;
 
 /**
- * Implementation of {@link ApiMetadata} for the Rackspace Autoscale API
- * 
+ * Implementation of {@link org.jclouds.apis.ApiMetadata} for the Rackspace Auto Scale API.
+ *
  * @see AutoscaleApi
  */
 public class AutoscaleApiMetadata extends BaseHttpApiMetadata<AutoscaleApi> {
@@ -63,7 +63,7 @@ public class AutoscaleApiMetadata extends BaseHttpApiMetadata<AutoscaleApi> {
 
    public static class Builder extends BaseHttpApiMetadata.Builder<AutoscaleApi, Builder> {
 
-      protected Builder() {   
+      protected Builder() {
          id("rackspace-autoscale")
          .name("Rackspace Autoscale API")
          .identityName("${tenantName}:${userName} or ${userName}, if your keystone supports a default tenant")
@@ -76,7 +76,7 @@ public class AutoscaleApiMetadata extends BaseHttpApiMetadata<AutoscaleApi> {
          .defaultModules(ImmutableSet.<Class<? extends Module>>builder()
                .add(CloudIdentityAuthenticationApiModule.class)
                .add(CloudIdentityAuthenticationModule.class)
-               .add(ZoneModule.class)
+               .add(RegionModule.class)
                .add(AutoscaleParserModule.class)
                .add(AutoscaleHttpApiModule.class)
                .build());

--- a/rackspace-autoscale/src/main/java/org/jclouds/rackspace/autoscale/v1/domain/CreateScalingPolicy.java
+++ b/rackspace-autoscale/src/main/java/org/jclouds/rackspace/autoscale/v1/domain/CreateScalingPolicy.java
@@ -23,15 +23,19 @@ import java.beans.ConstructorProperties;
 import java.util.EnumSet;
 import java.util.Map;
 
+
 import com.google.common.base.MoreObjects;
 import com.google.common.base.MoreObjects.ToStringHelper;
+
+import org.jclouds.rackspace.autoscale.v1.features.GroupApi;
+
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 
 /**
  * Auto Scale ScalingPolicy. This class is used for requests.
- * 
+ *
  * @see GroupApi#create(GroupConfiguration, LaunchConfiguration, java.util.List)
  * @see Group#getScalingPolicies()
  * @see ScalingPolicy
@@ -63,7 +67,7 @@ public class CreateScalingPolicy implements Comparable<CreateScalingPolicy> {
     */
    public String getName() {
       return this.name;
-   }   
+   }
 
    /**
     * @return the type for this ScalingPolicy.
@@ -84,7 +88,7 @@ public class CreateScalingPolicy implements Comparable<CreateScalingPolicy> {
 
    /**
     * @return the target for this ScalingPolicy. This is a numeric value, but could represent a 0-100% for some target types. Scale-down policies might have negative values.
-    * 
+    *
     * @see CreateScalingPolicy.Builder#target(int)
     */
    public String getTarget() {
@@ -147,7 +151,7 @@ public class CreateScalingPolicy implements Comparable<CreateScalingPolicy> {
       if (this == obj) return true;
       if (obj == null || getClass() != obj.getClass()) return false;
       CreateScalingPolicy that = CreateScalingPolicy.class.cast(obj);
-      return Objects.equal(this.name, that.name) && 
+      return Objects.equal(this.name, that.name) &&
             Objects.equal(this.type, that.type) &&
             Objects.equal(this.cooldown, that.cooldown) &&
             Objects.equal(this.target, that.target) &&
@@ -170,11 +174,11 @@ public class CreateScalingPolicy implements Comparable<CreateScalingPolicy> {
       return string().toString();
    }
 
-   public static Builder builder() { 
+   public static Builder builder() {
       return new Builder();
    }
 
-   public Builder toBuilder() { 
+   public Builder toBuilder() {
       return new Builder().fromScalingPolicy(this);
    }
 
@@ -186,7 +190,7 @@ public class CreateScalingPolicy implements Comparable<CreateScalingPolicy> {
       protected ScalingPolicyTargetType targetType;
       protected Map<String, String> args;
 
-      /** 
+      /**
        * @param name The name of this ScalingPolicy.
        * @return The builder object.
        * @see CreateScalingPolicy#getName()
@@ -196,7 +200,7 @@ public class CreateScalingPolicy implements Comparable<CreateScalingPolicy> {
          return this;
       }
 
-      /** 
+      /**
        * @param type The type for this ScalingPolicy.
        * @return The builder object.
        * @see ScalingPolicyType
@@ -207,7 +211,7 @@ public class CreateScalingPolicy implements Comparable<CreateScalingPolicy> {
          return this;
       }
 
-      /** 
+      /**
        * @param cooldown The cooldown of this ScalingPolicy.
        * @return The builder object.
        * @see CreateScalingPolicy#getCooldown()
@@ -217,7 +221,7 @@ public class CreateScalingPolicy implements Comparable<CreateScalingPolicy> {
          return this;
       }
 
-      /** 
+      /**
        * @param target The target of this ScalingPolicy.
        * @return The builder object.
        * @see CreateScalingPolicy#getTarget()
@@ -227,7 +231,7 @@ public class CreateScalingPolicy implements Comparable<CreateScalingPolicy> {
          return this;
       }
 
-      /** 
+      /**
        * @param targetType The target type of this ScalingPolicy.
        * @return The builder object.
        * @see ScalingPolicyTargetType
@@ -238,8 +242,8 @@ public class CreateScalingPolicy implements Comparable<CreateScalingPolicy> {
          return this;
       }
 
-      /** 
-       * @param cron This parameter specifies the recurring time when the policy will be executed as a cron entry. 
+      /**
+       * @param cron This parameter specifies the recurring time when the policy will be executed as a cron entry.
        * For example, if this is parameter is set to "1 0 * * *",
        * the policy will be executed at one minute past midnight (00:01)
        * every day of the month, and every day of the week.
@@ -255,7 +259,7 @@ public class CreateScalingPolicy implements Comparable<CreateScalingPolicy> {
          return this;
       }
 
-      /** 
+      /**
        * @param at This parameter specifies the time at which this policy will be executed.
        * This property is mutually exclusive with the "cron" parameter.
        * You can either provide "cron" or "at" for a given policy, but not both.
@@ -294,7 +298,7 @@ public class CreateScalingPolicy implements Comparable<CreateScalingPolicy> {
                .target(in.getTarget())
                .targetType(in.getTargetType())
                .scheduleArgs(in.getSchedulingArgs());
-      }        
+      }
    }
 
    @Override

--- a/rackspace-autoscale/src/main/java/org/jclouds/rackspace/autoscale/v1/domain/GroupConfiguration.java
+++ b/rackspace-autoscale/src/main/java/org/jclouds/rackspace/autoscale/v1/domain/GroupConfiguration.java
@@ -22,6 +22,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.beans.ConstructorProperties;
 import java.util.Map;
 
+import org.jclouds.rackspace.autoscale.v1.features.GroupApi;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.MoreObjects.ToStringHelper;

--- a/rackspace-autoscale/src/main/java/org/jclouds/rackspace/autoscale/v1/domain/GroupState.java
+++ b/rackspace-autoscale/src/main/java/org/jclouds/rackspace/autoscale/v1/domain/GroupState.java
@@ -20,6 +20,7 @@ import java.beans.ConstructorProperties;
 import java.util.List;
 
 import org.jclouds.openstack.v2_0.domain.Link;
+import org.jclouds.rackspace.autoscale.v1.features.GroupApi;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.MoreObjects.ToStringHelper;

--- a/rackspace-autoscale/src/main/java/org/jclouds/rackspace/autoscale/v1/domain/LaunchConfiguration.java
+++ b/rackspace-autoscale/src/main/java/org/jclouds/rackspace/autoscale/v1/domain/LaunchConfiguration.java
@@ -21,6 +21,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 
+import org.jclouds.rackspace.autoscale.v1.features.GroupApi;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.MoreObjects.ToStringHelper;

--- a/rackspace-autoscale/src/main/java/org/jclouds/rackspace/autoscale/v1/features/GroupApi.java
+++ b/rackspace-autoscale/src/main/java/org/jclouds/rackspace/autoscale/v1/features/GroupApi.java
@@ -31,15 +31,16 @@ import javax.ws.rs.core.MediaType;
 
 import org.jclouds.Fallbacks.FalseOnNotFoundOr404;
 import org.jclouds.Fallbacks.NullOnNotFoundOr404;
+import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.openstack.keystone.v2_0.filters.AuthenticateRequest;
 import org.jclouds.rackspace.autoscale.v1.binders.BindCreateGroupToJson;
 import org.jclouds.rackspace.autoscale.v1.binders.BindLaunchConfigurationToJson;
 import org.jclouds.rackspace.autoscale.v1.binders.BindToGroupConfigurationRequestPayload;
+import org.jclouds.rackspace.autoscale.v1.domain.CreateScalingPolicy;
 import org.jclouds.rackspace.autoscale.v1.domain.Group;
 import org.jclouds.rackspace.autoscale.v1.domain.GroupConfiguration;
 import org.jclouds.rackspace.autoscale.v1.domain.GroupState;
 import org.jclouds.rackspace.autoscale.v1.domain.LaunchConfiguration;
-import org.jclouds.rackspace.autoscale.v1.domain.CreateScalingPolicy;
 import org.jclouds.rackspace.autoscale.v1.functions.ParseGroupLaunchConfigurationResponse;
 import org.jclouds.rackspace.autoscale.v1.functions.ParseGroupResponse;
 import org.jclouds.rest.annotations.Fallback;
@@ -57,6 +58,7 @@ import com.google.common.collect.FluentIterable;
  */
 @RequestFilters(AuthenticateRequest.class)
 @Consumes(MediaType.APPLICATION_JSON)
+@Path("/groups")
 public interface GroupApi extends Closeable {
 
    /**
@@ -70,13 +72,13 @@ public interface GroupApi extends Closeable {
     * @see CreateScalingPolicy
     * @see Group
     */
-   @Named("Group:create")
+   @Named("group:create")
    @POST
-   @Path("/groups")
-   @Fallback(NullOnNotFoundOr404.class)
    @MapBinder(BindCreateGroupToJson.class)
    @ResponseParser(ParseGroupResponse.class)
-   Group create(@PayloadParam("groupConfiguration") GroupConfiguration groupConfiguration, 
+   @Fallback(NullOnNotFoundOr404.class)
+   @Nullable
+   Group create(@PayloadParam("groupConfiguration") GroupConfiguration groupConfiguration,
          @PayloadParam("launchConfiguration") LaunchConfiguration launchConfiguration,
          @PayloadParam("scalingPolicies") List<CreateScalingPolicy> scalingPolicies);
 
@@ -87,9 +89,9 @@ public interface GroupApi extends Closeable {
     * @return true if successful.
     * @see GroupApi#resume(String)
     */
-   @Named("Groups:pause/{groupId}")
+   @Named("group:pause")
    @POST
-   @Path("/groups/{groupId}/pause")
+   @Path("/{groupId}/pause")
    @Fallback(FalseOnNotFoundOr404.class)
    boolean pause(@PathParam("groupId") String groupId);
 
@@ -100,9 +102,9 @@ public interface GroupApi extends Closeable {
     * @return true if successful.
     * @see GroupApi#pause(String)
     */
-   @Named("Groups:resume/{groupId}")
+   @Named("group:resume")
    @POST
-   @Path("/groups/{groupId}/resume")
+   @Path("/{groupId}/resume")
    @Fallback(FalseOnNotFoundOr404.class)
    boolean resume(@PathParam("groupId") String groupId);
 
@@ -112,9 +114,9 @@ public interface GroupApi extends Closeable {
     * @param groupId The id for the specified Group.
     * @return true if successful.
     */
-   @Named("Groups:delete/{id}")
+   @Named("group:delete")
    @DELETE
-   @Path("/groups/{id}")
+   @Path("/{id}")
    @Fallback(FalseOnNotFoundOr404.class)
    boolean delete(@PathParam("id") String groupId);
 
@@ -123,11 +125,12 @@ public interface GroupApi extends Closeable {
     * @param id The unique identifier of the scaling group.
     * @return Group Full details for the scaling group.
     */
-   @Named("Group:get/{id}")
+   @Named("group:get")
    @GET
-   @Path("/groups/{id}")
+   @Path("/{id}")
    @ResponseParser(ParseGroupResponse.class)
    @Fallback(NullOnNotFoundOr404.class)
+   @Nullable
    Group get(@PathParam("id") String id);
 
    /**
@@ -136,11 +139,12 @@ public interface GroupApi extends Closeable {
     * @return The state of the Group.
     * @see GroupState
     */
-   @Named("Group:state")
+   @Named("group:getState")
    @GET
-   @Path("/groups/{id}/state")
+   @Path("/{id}/state")
    @SelectJson("group")
    @Fallback(NullOnNotFoundOr404.class)
+   @Nullable
    GroupState getState(@PathParam("id") String id);
 
    /**
@@ -148,59 +152,60 @@ public interface GroupApi extends Closeable {
     * @return A list of group states for all scaling groups.
     * @see GroupState
     */
-   @Named("Group:states")
+   @Named("group:listGroupStates")
    @GET
-   @Path("/groups")
    @SelectJson("groups")
    FluentIterable<GroupState> listGroupStates();
-   
+
    /**
     * This operation gets the configuration for the scaling group.
     * @return The group configuration for the scaling group.
     * @see GroupConfiguration
     */
-   @Named("Group:configuration")
+   @Named("group:getGroupConfiguration")
    @GET
-   @Path("/groups/{groupId}/config")
+   @Path("/{groupId}/config")
    @SelectJson("groupConfiguration")
    @Fallback(NullOnNotFoundOr404.class)
+   @Nullable
    GroupConfiguration getGroupConfiguration(@PathParam("groupId") String id);
-   
+
    /**
     * This operation updates the configuration for the scaling group.
     * @return true if successful.
     * @see GroupConfiguration
     */
-   @Named("Group:updateConfiguration")
+   @Named("group:updateGroupConfiguration")
    @PUT
-   @Path("/groups/{groupId}/config")
+   @Path("/{groupId}/config")
    @Fallback(FalseOnNotFoundOr404.class)
    @MapBinder(BindToGroupConfigurationRequestPayload.class)
    boolean updateGroupConfiguration(@PathParam("groupId") String id,
          @PayloadParam("groupConfiguration") GroupConfiguration groupConfiguration);
-   
+
    /**
     * This operation gets the launch configuration for the scaling group.
     * @return The launch configuration for the scaling group.
     * @see LaunchConfiguration
     */
-   @Named("Group:launchConfiguration")
+   @Named("group:getLaunchConfiguration")
    @GET
-   @Path("/groups/{groupId}/launch")
-   @Fallback(NullOnNotFoundOr404.class)
+   @Path("/{groupId}/launch")
    @ResponseParser(ParseGroupLaunchConfigurationResponse.class)
+   @Fallback(NullOnNotFoundOr404.class)
+   @Nullable
    LaunchConfiguration getLaunchConfiguration(@PathParam("groupId") String id);
-   
+
    /**
     * This operation updates the launch configuration for the scaling group.
     * @return true if successful.
     * @see LaunchConfiguration
     */
-   @Named("Group:updateLaunchConfiguration")
+   @Named("group:updateLaunchConfiguration")
    @PUT
-   @Path("/groups/{groupId}/launch")
+   @Path("/{groupId}/launch")
    @Fallback(FalseOnNotFoundOr404.class)
    @MapBinder(BindLaunchConfigurationToJson.class)
-   boolean updateLaunchConfiguration(@PathParam("groupId") String id, 
+   boolean updateLaunchConfiguration(@PathParam("groupId") String id,
          @PayloadParam("launchConfiguration") LaunchConfiguration launchConfiguration);
 }

--- a/rackspace-autoscale/src/main/java/org/jclouds/rackspace/autoscale/v1/features/PolicyApi.java
+++ b/rackspace-autoscale/src/main/java/org/jclouds/rackspace/autoscale/v1/features/PolicyApi.java
@@ -33,6 +33,7 @@ import javax.ws.rs.core.MediaType;
 import org.jclouds.Fallbacks.EmptyFluentIterableOnNotFoundOr404;
 import org.jclouds.Fallbacks.FalseOnNotFoundOr404;
 import org.jclouds.Fallbacks.NullOnNotFoundOr404;
+import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.openstack.keystone.v2_0.filters.AuthenticateRequest;
 import org.jclouds.rackspace.autoscale.v1.binders.BindScalingPoliciesToJson;
 import org.jclouds.rackspace.autoscale.v1.binders.BindScalingPolicyToJson;
@@ -54,6 +55,7 @@ import com.google.common.collect.FluentIterable;
  */
 @RequestFilters(AuthenticateRequest.class)
 @Consumes(MediaType.APPLICATION_JSON)
+@Path("/policies")
 public interface PolicyApi extends Closeable {
    /**
     * Create a scaling policy.
@@ -62,9 +64,9 @@ public interface PolicyApi extends Closeable {
     * @see CreateScalingPolicy
     * @see ScalingPolicy
     */
-   @Named("Policy:create")
+   @Named("policy:create")
    @POST
-   @Path("/policies")
+   //@Path("/policies")
    @Fallback(EmptyFluentIterableOnNotFoundOr404.class)
    @MapBinder(BindScalingPoliciesToJson.class)
    @ResponseParser(ParseScalingPoliciesResponse.class)
@@ -75,9 +77,9 @@ public interface PolicyApi extends Closeable {
     * @return A list of scaling policy responses.
     * @see ScalingPolicy
     */
-   @Named("Policy:list")
+   @Named("policy:list")
    @GET
-   @Path("/policies")
+   //@Path("/policies")
    @ResponseParser(ParseScalingPoliciesResponse.class)
    @Fallback(EmptyFluentIterableOnNotFoundOr404.class)
    FluentIterable<ScalingPolicy> list();
@@ -87,11 +89,12 @@ public interface PolicyApi extends Closeable {
     * @return Existing scaling policy details
     * @see ScalingPolicy
     */
-   @Named("Policy:get")
+   @Named("policy:get")
    @GET
-   @Path("/policies/{scalingPolicyId}")
+   @Path("/{scalingPolicyId}")
    @ResponseParser(ParseScalingPolicyResponse.class)
    @Fallback(NullOnNotFoundOr404.class)
+   @Nullable
    ScalingPolicy get(@PathParam("scalingPolicyId") String scalingPolicyId);
 
    /**
@@ -99,21 +102,22 @@ public interface PolicyApi extends Closeable {
     * @return true if successful.
     * @see CreateScalingPolicy
     */
-   @Named("Policy:update")
+   @Named("policy:update")
    @PUT
-   @Path("/policies/{scalingPolicyId}")
+   @Path("/{scalingPolicyId}")
    @MapBinder(BindScalingPolicyToJson.class)
    @Fallback(FalseOnNotFoundOr404.class)
-   boolean update(@PathParam("scalingPolicyId") String scalingPolicyId, @PayloadParam("scalingPolicy") CreateScalingPolicy scalingPolicy);
+   boolean update(@PathParam("scalingPolicyId") String scalingPolicyId,
+         @PayloadParam("scalingPolicy") CreateScalingPolicy scalingPolicy);
 
    /**
     * This operation deletes a specific scaling policy.
     * @return true if successful.
     * @see CreateScalingPolicy
     */
-   @Named("Policy:delete")
+   @Named("policy:delete")
    @DELETE
-   @Path("/policies/{scalingPolicyId}")
+   @Path("/{scalingPolicyId}")
    @Fallback(FalseOnNotFoundOr404.class)
    boolean delete(@PathParam("scalingPolicyId") String scalingPolicyId);
 
@@ -122,9 +126,9 @@ public interface PolicyApi extends Closeable {
     * @return true if successful.
     * @see CreateScalingPolicy
     */
-   @Named("Policy:execute")
+   @Named("policy:execute")
    @POST
-   @Path("/policies/{scalingPolicyId}/execute")
+   @Path("/{scalingPolicyId}/execute")
    @Fallback(FalseOnNotFoundOr404.class)
    boolean execute(@PathParam("scalingPolicyId") String scalingPolicyId);
 }

--- a/rackspace-autoscale/src/main/java/org/jclouds/rackspace/autoscale/v1/features/WebhookApi.java
+++ b/rackspace-autoscale/src/main/java/org/jclouds/rackspace/autoscale/v1/features/WebhookApi.java
@@ -33,11 +33,14 @@ import javax.ws.rs.core.MediaType;
 import org.jclouds.Fallbacks.EmptyFluentIterableOnNotFoundOr404;
 import org.jclouds.Fallbacks.FalseOnNotFoundOr404;
 import org.jclouds.Fallbacks.NullOnNotFoundOr404;
+import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.openstack.keystone.v2_0.filters.AuthenticateRequest;
 import org.jclouds.rackspace.autoscale.v1.binders.BindWebhookToJson;
 import org.jclouds.rackspace.autoscale.v1.binders.BindWebhookUpdateToJson;
 import org.jclouds.rackspace.autoscale.v1.binders.BindWebhooksToJson;
+import org.jclouds.rackspace.autoscale.v1.domain.CreateScalingPolicy;
 import org.jclouds.rackspace.autoscale.v1.domain.CreateWebhook;
+import org.jclouds.rackspace.autoscale.v1.domain.Group;
 import org.jclouds.rackspace.autoscale.v1.domain.Webhook;
 import org.jclouds.rest.annotations.Fallback;
 import org.jclouds.rest.annotations.MapBinder;
@@ -48,15 +51,16 @@ import org.jclouds.rest.annotations.SelectJson;
 import com.google.common.collect.FluentIterable;
 
 /**
- * The API for controlling autoscale webhooks.
+ * The API for controlling Auto Scale Webhooks.
  */
 @RequestFilters(AuthenticateRequest.class)
 @Consumes(MediaType.APPLICATION_JSON)
+@Path("/webhooks")
 public interface WebhookApi extends Closeable {
    /**
     * Create a webhook.
     * @param name The webhook name. Required.
-    * @param metadata A map of associated metadata. Use String keys. Required. 
+    * @param metadata A map of associated metadata. Use String keys. Required.
     * @return WebhookResponse The webhook created by this call.
     * @see CreateWebhook
     * @see Webhook
@@ -65,11 +69,11 @@ public interface WebhookApi extends Closeable {
     */
    @Named("Webhook:create")
    @POST
-   @Path("/webhooks")
-   @Fallback(EmptyFluentIterableOnNotFoundOr404.class)
-   @MapBinder(BindWebhookToJson.class)
    @SelectJson("webhooks")
-   FluentIterable<Webhook> create(@PayloadParam("name") String name, @PayloadParam("metadata") Map<String, Object> metadata);
+   @MapBinder(BindWebhookToJson.class)
+   @Fallback(EmptyFluentIterableOnNotFoundOr404.class)
+   FluentIterable<Webhook> create(@PayloadParam("name") String name,
+         @PayloadParam("metadata") Map<String, Object> metadata);
 
    /**
     * Create webhooks.
@@ -80,14 +84,13 @@ public interface WebhookApi extends Closeable {
     * @see Group
     * @see CreateScalingPolicy
     */
-   @Named("Webhook:create")
+   @Named("webhook:create")
    @POST
-   @Path("/webhooks")
-   @Fallback(EmptyFluentIterableOnNotFoundOr404.class)
-   @MapBinder(BindWebhooksToJson.class)
    @SelectJson("webhooks")
+   @MapBinder(BindWebhooksToJson.class)
+   @Fallback(EmptyFluentIterableOnNotFoundOr404.class)
    FluentIterable<Webhook> create(@PayloadParam("webhooks") List<CreateWebhook> webhooks);
-   
+
    /**
     * List webhooks.
     * @return A list of webhooks
@@ -98,9 +101,8 @@ public interface WebhookApi extends Closeable {
     */
    @Named("Webhook:list")
    @GET
-   @Path("/webhooks")
-   @Fallback(EmptyFluentIterableOnNotFoundOr404.class)
    @SelectJson("webhooks")
+   @Fallback(EmptyFluentIterableOnNotFoundOr404.class)
    FluentIterable<Webhook> list();
 
    /**
@@ -112,11 +114,12 @@ public interface WebhookApi extends Closeable {
     * @see Group
     * @see CreateScalingPolicy
     */
-   @Named("Webhook:get")
+   @Named("webhook:get")
    @GET
-   @Path("/webhooks/{webhookId}")   
-   @Fallback(NullOnNotFoundOr404.class)
+   @Path("/{webhookId}")
    @SelectJson("webhook")
+   @Fallback(NullOnNotFoundOr404.class)
+   @Nullable
    Webhook get(@PathParam("webhookId") String id);
 
    /**
@@ -130,12 +133,13 @@ public interface WebhookApi extends Closeable {
     * @see Group
     * @see CreateScalingPolicy
     */
-   @Named("Webhook:update")
+   @Named("webhook:update")
    @PUT
-   @Path("/webhooks/{webhookId}")   
-   @Fallback(FalseOnNotFoundOr404.class)
+   @Path("/{webhookId}")
    @MapBinder(BindWebhookUpdateToJson.class)
-   boolean update(@PathParam("webhookId") String id, @PayloadParam("name") String name, @PayloadParam("metadata") Map<String, Object> metadata);
+   @Fallback(FalseOnNotFoundOr404.class)
+   boolean update(@PathParam("webhookId") String id, @PayloadParam("name") String name,
+         @PayloadParam("metadata") Map<String, Object> metadata);
 
    /**
     * Delete a webhook.
@@ -146,9 +150,9 @@ public interface WebhookApi extends Closeable {
     * @see Group
     * @see CreateScalingPolicy
     */
-   @Named("Webhook:delete")
+   @Named("webhook:delete")
    @DELETE
-   @Path("/webhooks/{webhookId}")   
+   @Path("/{webhookId}")
    @Fallback(FalseOnNotFoundOr404.class)
    boolean delete(@PathParam("webhookId") String id);
 }

--- a/rackspace-autoscale/src/test/java/org/jclouds/rackspace/autoscale/v1/features/GroupApiLiveTest.java
+++ b/rackspace-autoscale/src/test/java/org/jclouds/rackspace/autoscale/v1/features/GroupApiLiveTest.java
@@ -59,10 +59,10 @@ public class GroupApiLiveTest extends BaseAutoscaleApiLiveTest {
    @BeforeClass(groups = { "integration", "live" })
    public void setup() {
       super.setup();
-      for (String zone : api.getConfiguredZones()) {
+      for (String region : api.getConfiguredRegions()) {
          List<Group> createdGroupList = Lists.newArrayList();
-         created.put(zone, createdGroupList);
-         GroupApi groupApi = api.getGroupApiForZone(zone);
+         created.put(region, createdGroupList);
+         GroupApi groupApi = api.getGroupApi(region);
 
          GroupConfiguration groupConfiguration = GroupConfiguration.builder().maxEntities(10).cooldown(360)
                .name("testscalinggroup198547").minEntities(0)
@@ -99,14 +99,14 @@ public class GroupApiLiveTest extends BaseAutoscaleApiLiveTest {
          assertNotNull(g.getId());
          assertEquals(g.getLinks().size(), 1);
          assertEquals(g.getLinks().get(0).getHref().toString(),
-               "https://" + zone.toLowerCase() + ".autoscale.api.rackspacecloud.com/v1.0/" + api.getCurrentTenantId().get().getId() + "/groups/" + g.getId() + "/");
+               "https://" + region.toLowerCase() + ".autoscale.api.rackspacecloud.com/v1.0/" + api.getCurrentTenantId().get().getId() + "/groups/" + g.getId() + "/");
          assertEquals(g.getLinks().get(0).getRelation(), Link.Relation.SELF);
 
          assertNotNull(g.getScalingPolicies().get(0).getId());
          assertEquals(g.getScalingPolicies().get(0).getLinks().size(), 1);
          assertEquals(
                g.getScalingPolicies().get(0).getLinks().get(0).getHref().toString(),
-               "https://" + zone.toLowerCase() + ".autoscale.api.rackspacecloud.com/v1.0/" + api.getCurrentTenantId().get().getId() + "/groups/" + g.getId() + "/policies/" + g.getScalingPolicies().get(0).getId() + "/");
+               "https://" + region.toLowerCase() + ".autoscale.api.rackspacecloud.com/v1.0/" + api.getCurrentTenantId().get().getId() + "/groups/" + g.getId() + "/policies/" + g.getScalingPolicies().get(0).getId() + "/");
          assertEquals(g.getScalingPolicies().get(0).getLinks().get(0).getRelation(), Link.Relation.SELF);
          assertEquals(g.getScalingPolicies().get(0).getCooldown(), 1);
          assertEquals(g.getScalingPolicies().get(0).getTarget(), "1");
@@ -145,9 +145,9 @@ public class GroupApiLiveTest extends BaseAutoscaleApiLiveTest {
 
    @Test
    public void testGetGroup() {
-      for (String zone : api.getConfiguredZones()) {
-         GroupApi groupApi = api.getGroupApiForZone(zone);
-         String groupId = created.get(zone).get(0).getId();
+      for (String region : api.getConfiguredRegions()) {
+         GroupApi groupApi = api.getGroupApi(region);
+         String groupId = created.get(region).get(0).getId();
          Group testGroup = groupApi.get(groupId);
          assertEquals(testGroup.getId(), groupId);
          assertEquals(testGroup.getGroupConfiguration().getCooldown(), 360);
@@ -158,9 +158,9 @@ public class GroupApiLiveTest extends BaseAutoscaleApiLiveTest {
 
    @Test
    public void testGetState() {
-      for (String zone : api.getConfiguredZones()) {
-         GroupApi groupApi = api.getGroupApiForZone(zone);
-         String groupId = created.get(zone).get(0).getId();
+      for (String region : api.getConfiguredRegions()) {
+         GroupApi groupApi = api.getGroupApi(region);
+         String groupId = created.get(region).get(0).getId();
          GroupState testGroup = groupApi.getState(groupId);
          assertNull(testGroup.getId()); // The id recently changed to not be included when getting state.
       }
@@ -168,10 +168,10 @@ public class GroupApiLiveTest extends BaseAutoscaleApiLiveTest {
 
    @Test
    public void testListGroups() {
-      for (String zone : api.getConfiguredZones()) {
-         GroupApi groupApi = api.getGroupApiForZone(zone);
+      for (String region : api.getConfiguredRegions()) {
+         GroupApi groupApi = api.getGroupApi(region);
          FluentIterable<GroupState> groupsList = groupApi.listGroupStates();
-         String groupId = created.get(zone).get(0).getId();
+         String groupId = created.get(region).get(0).getId();
          for (GroupState groupState : groupsList) {
             if (groupId.equals(groupState.getId())) {
                return;
@@ -184,18 +184,18 @@ public class GroupApiLiveTest extends BaseAutoscaleApiLiveTest {
    /* TODO: uncomment when implemented
    @Test
    public void testPause() {
-      for (String zone : api.getConfiguredZones()) {
-         GroupApi groupApi = api.getGroupApiForZone(zone);
-         String groupId = created.get(zone).get(0).getId();
+      for (String region : api.getConfiguredRegions()) {
+         GroupApi groupApi = api.getGroupApiForRegions(region);
+         String groupId = created.get(region).get(0).getId();
          assertTrue(groupApi.pause(groupId));
       }
    }
 
    @Test
    public void testResume() {
-      for (String zone : api.getConfiguredZones()) {
-         GroupApi groupApi = api.getGroupApiForZone(zone);
-         String groupId = created.get(zone).get(0).getId();
+      for (String region : api.getConfiguredRegions()) {
+         GroupApi groupApi = api.getGroupApiForRegions(region);
+         String groupId = created.get(region).get(0).getId();
          assertTrue(groupApi.resume(groupId));
       }
    }
@@ -203,9 +203,9 @@ public class GroupApiLiveTest extends BaseAutoscaleApiLiveTest {
 
    @Test
    public void testGetGroupConfiguration() {
-      for (String zone : api.getConfiguredZones()) {
-         GroupApi groupApi = api.getGroupApiForZone(zone);
-         String groupId = created.get(zone).get(0).getId();
+      for (String region : api.getConfiguredRegions()) {
+         GroupApi groupApi = api.getGroupApi(region);
+         String groupId = created.get(region).get(0).getId();
          GroupConfiguration testGroupConfiguration = groupApi.getGroupConfiguration(groupId);
          assertEquals(testGroupConfiguration.getCooldown(), 360);
          assertEquals(testGroupConfiguration.getMaxEntities(), 10);
@@ -215,9 +215,9 @@ public class GroupApiLiveTest extends BaseAutoscaleApiLiveTest {
 
    @Test
    public void testGetGroupLaunchConfiguration() {
-      for (String zone : api.getConfiguredZones()) {
-         GroupApi groupApi = api.getGroupApiForZone(zone);
-         String groupId = created.get(zone).get(0).getId();
+      for (String region : api.getConfiguredRegions()) {
+         GroupApi groupApi = api.getGroupApi(region);
+         String groupId = created.get(region).get(0).getId();
          LaunchConfiguration testLaunchConfiguration = groupApi.getLaunchConfiguration(groupId);
          assertEquals(testLaunchConfiguration.getLoadBalancers().get(0).getPort(), 8080);
          assertEquals(testLaunchConfiguration.getType(), LaunchConfigurationType.LAUNCH_SERVER);
@@ -227,9 +227,9 @@ public class GroupApiLiveTest extends BaseAutoscaleApiLiveTest {
 
    @Test
    public void testUpdateLaunchConfiguration() {
-      for (String zone : api.getConfiguredZones()) {
-         GroupApi groupApi = api.getGroupApiForZone(zone);
-         String groupId = created.get(zone).get(0).getId();
+      for (String region : api.getConfiguredRegions()) {
+         GroupApi groupApi = api.getGroupApi(region);
+         String groupId = created.get(region).get(0).getId();
 
          LaunchConfiguration launchConfiguration = LaunchConfiguration
                .builder()
@@ -255,9 +255,9 @@ public class GroupApiLiveTest extends BaseAutoscaleApiLiveTest {
 
    @Test
    public void testUpdateGroupConfiguration() {
-      for (String zone : api.getConfiguredZones()) {
-         GroupApi groupApi = api.getGroupApiForZone(zone);
-         String groupId = created.get(zone).get(0).getId();
+      for (String region : api.getConfiguredRegions()) {
+         GroupApi groupApi = api.getGroupApi(region);
+         String groupId = created.get(region).get(0).getId();
 
          GroupConfiguration groupConfiguration = GroupConfiguration.builder().maxEntities(10).cooldown(360)
                .name("testscalinggroup198547").minEntities(0)
@@ -272,9 +272,9 @@ public class GroupApiLiveTest extends BaseAutoscaleApiLiveTest {
    @Override
    @AfterClass(groups = { "integration", "live" })
    public void tearDown() {
-      for (String zone : api.getConfiguredZones()) {
-         GroupApi groupApi = api.getGroupApiForZone(zone);
-         for (Group group : created.get(zone)) {
+      for (String region : api.getConfiguredRegions()) {
+         GroupApi groupApi = api.getGroupApi(region);
+         for (Group group : created.get(region)) {
             if (!groupApi.delete(group.getId()))
                throw new RuntimeException("Could not delete an autoscale group after tests!");
          }

--- a/rackspace-autoscale/src/test/java/org/jclouds/rackspace/autoscale/v1/features/GroupApiMockTest.java
+++ b/rackspace-autoscale/src/test/java/org/jclouds/rackspace/autoscale/v1/features/GroupApiMockTest.java
@@ -60,7 +60,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         GroupApi api = autoscaleApi.getGroupApiForZone("DFW");
+         GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          GroupConfiguration groupConfiguration = GroupConfiguration.builder()
                .maxEntities(10)
@@ -157,7 +157,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         GroupApi api = autoscaleApi.getGroupApiForZone("DFW");
+         GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          GroupConfiguration groupConfiguration = GroupConfiguration.builder()
                .maxEntities(10)
@@ -211,7 +211,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         GroupApi api = autoscaleApi.getGroupApiForZone("DFW");
+         GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          FluentIterable<GroupState> groupStates = api.listGroupStates();
 
@@ -248,7 +248,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         GroupApi api = autoscaleApi.getGroupApiForZone("DFW");
+         GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          FluentIterable<GroupState> groupStates = api.listGroupStates();
 
@@ -274,7 +274,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         GroupApi api = autoscaleApi.getGroupApiForZone("DFW");
+         GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          Group g = api.get("1234567890");
 
@@ -301,7 +301,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         GroupApi api = autoscaleApi.getGroupApiForZone("DFW");
+         GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          Group g = api.get("1234567890");
 
@@ -327,7 +327,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         GroupApi api = autoscaleApi.getGroupApiForZone("DFW");
+         GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          boolean success = api.delete("1234567890");
 
@@ -353,7 +353,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         GroupApi api = autoscaleApi.getGroupApiForZone("DFW");
+         GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          boolean success = api.delete("1234567890");
 
@@ -379,7 +379,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         GroupApi api = autoscaleApi.getGroupApiForZone("DFW");
+         GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          GroupState gs = api.getState("1234567890");
 
@@ -407,7 +407,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         GroupApi api = autoscaleApi.getGroupApiForZone("DFW");
+         GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          GroupState gs = api.getState("1234567890");
 
@@ -433,7 +433,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         GroupApi api = autoscaleApi.getGroupApiForZone("DFW");
+         GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          boolean success = api.pause("1234567890");
 
@@ -459,7 +459,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         GroupApi api = autoscaleApi.getGroupApiForZone("DFW");
+         GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          boolean success = api.pause("1234567890");
 
@@ -485,7 +485,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         GroupApi api = autoscaleApi.getGroupApiForZone("DFW");
+         GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          boolean success = api.resume("1234567890");
 
@@ -511,7 +511,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         GroupApi api = autoscaleApi.getGroupApiForZone("DFW");
+         GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          boolean success = api.resume("1234567890");
 
@@ -537,7 +537,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         GroupApi api = autoscaleApi.getGroupApiForZone("DFW");
+         GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          GroupConfiguration gc = api.getGroupConfiguration("1234567890");
 
@@ -564,7 +564,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         GroupApi api = autoscaleApi.getGroupApiForZone("DFW");
+         GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          GroupConfiguration gc = api.getGroupConfiguration("1234567890");
 
@@ -590,7 +590,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         GroupApi api = autoscaleApi.getGroupApiForZone("DFW");
+         GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          LaunchConfiguration lc = api.getLaunchConfiguration("1234567890");
 
@@ -617,7 +617,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         GroupApi api = autoscaleApi.getGroupApiForZone("DFW");
+         GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          LaunchConfiguration lc = api.getLaunchConfiguration("1234567890");
 
@@ -643,7 +643,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         GroupApi api = autoscaleApi.getGroupApiForZone("DFW");
+         GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          GroupConfiguration gc = GroupConfiguration.builder()
                .name("workers")
@@ -677,7 +677,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         GroupApi api = autoscaleApi.getGroupApiForZone("DFW");
+         GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          GroupConfiguration gc = GroupConfiguration.builder()
                .name("workers")
@@ -711,7 +711,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         GroupApi api = autoscaleApi.getGroupApiForZone("DFW");
+         GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          LaunchConfiguration lc = LaunchConfiguration.builder()
                .loadBalancers(ImmutableList.of(LoadBalancer.builder().port(8080).id(9099).build()))
@@ -749,7 +749,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         GroupApi api = autoscaleApi.getGroupApiForZone("DFW");
+         GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          LaunchConfiguration lc = LaunchConfiguration.builder()
                .loadBalancers(ImmutableList.of(LoadBalancer.builder().port(8080).id(9099).build()))

--- a/rackspace-autoscale/src/test/java/org/jclouds/rackspace/autoscale/v1/features/ScalingPolicyApiLiveTest.java
+++ b/rackspace-autoscale/src/test/java/org/jclouds/rackspace/autoscale/v1/features/ScalingPolicyApiLiveTest.java
@@ -60,10 +60,10 @@ public class ScalingPolicyApiLiveTest extends BaseAutoscaleApiLiveTest {
    @BeforeClass(groups = { "integration", "live" })
    public void setup() {
       super.setup();
-      for (String zone : api.getConfiguredZones()) {
+      for (String region : api.getConfiguredRegions()) {
          List<Group> createdGroupList = Lists.newArrayList();
-         created.put(zone, createdGroupList);
-         GroupApi groupApi = api.getGroupApiForZone(zone);
+         created.put(region, createdGroupList);
+         GroupApi groupApi = api.getGroupApi(region);
 
          GroupConfiguration groupConfiguration = GroupConfiguration.builder().maxEntities(10).cooldown(3)
                .name("testscalinggroup198547").minEntities(0)
@@ -100,14 +100,14 @@ public class ScalingPolicyApiLiveTest extends BaseAutoscaleApiLiveTest {
          assertNotNull(g.getId());
          assertEquals(g.getLinks().size(), 1);
          assertEquals(g.getLinks().get(0).getHref().toString(),
-               "https://" + zone.toLowerCase() + ".autoscale.api.rackspacecloud.com/v1.0/" + api.getCurrentTenantId().get().getId() + "/groups/" + g.getId() + "/");
+               "https://" + region.toLowerCase() + ".autoscale.api.rackspacecloud.com/v1.0/" + api.getCurrentTenantId().get().getId() + "/groups/" + g.getId() + "/");
          assertEquals(g.getLinks().get(0).getRelation(), Link.Relation.SELF);
 
          assertNotNull(g.getScalingPolicies().get(0).getId());
          assertEquals(g.getScalingPolicies().get(0).getLinks().size(), 1);
          assertEquals(
                g.getScalingPolicies().get(0).getLinks().get(0).getHref().toString(),
-               "https://" + zone.toLowerCase() + ".autoscale.api.rackspacecloud.com/v1.0/" + api.getCurrentTenantId().get().getId() + "/groups/" + g.getId() + "/policies/" + g.getScalingPolicies().get(0).getId() + "/");
+               "https://" + region.toLowerCase() + ".autoscale.api.rackspacecloud.com/v1.0/" + api.getCurrentTenantId().get().getId() + "/groups/" + g.getId() + "/policies/" + g.getScalingPolicies().get(0).getId() + "/");
          assertEquals(g.getScalingPolicies().get(0).getLinks().get(0).getRelation(), Link.Relation.SELF);
          assertEquals(g.getScalingPolicies().get(0).getCooldown(), 3);
          assertEquals(g.getScalingPolicies().get(0).getTarget(), "1");
@@ -146,9 +146,9 @@ public class ScalingPolicyApiLiveTest extends BaseAutoscaleApiLiveTest {
 
    @Test
    public void testCreatePolicy() {
-      for (String zone : api.getConfiguredZones()) {
+      for (String region : api.getConfiguredRegions()) {
 
-         PolicyApi policyApi = api.getPolicyApiForZoneAndGroup(zone, created.get(zone).get(0).getId());
+         PolicyApi policyApi = api.getPolicyApi(region, created.get(region).get(0).getId());
 
          List<CreateScalingPolicy> scalingPolicies = Lists.newArrayList();
 
@@ -170,9 +170,9 @@ public class ScalingPolicyApiLiveTest extends BaseAutoscaleApiLiveTest {
 
    @Test
    public void testCreateScheduleCronPolicy() {
-      for (String zone : api.getConfiguredZones()) {
+      for (String region : api.getConfiguredRegions()) {
 
-         PolicyApi policyApi = api.getPolicyApiForZoneAndGroup(zone, created.get(zone).get(0).getId());
+         PolicyApi policyApi = api.getPolicyApi(region, created.get(region).get(0).getId());
 
          List<CreateScalingPolicy> scalingPolicies = Lists.newArrayList();
 
@@ -197,9 +197,9 @@ public class ScalingPolicyApiLiveTest extends BaseAutoscaleApiLiveTest {
 
    @Test
    public void testCreateScheduleAtPolicy() {
-      for (String zone : api.getConfiguredZones()) {
+      for (String region : api.getConfiguredRegions()) {
 
-         PolicyApi policyApi = api.getPolicyApiForZoneAndGroup(zone, created.get(zone).get(0).getId());
+         PolicyApi policyApi = api.getPolicyApi(region, created.get(region).get(0).getId());
 
          List<CreateScalingPolicy> scalingPolicies = Lists.newArrayList();
 
@@ -224,9 +224,9 @@ public class ScalingPolicyApiLiveTest extends BaseAutoscaleApiLiveTest {
 
    @Test
    public void testListPolicy() {
-      for (String zone : api.getConfiguredZones()) {
+      for (String region : api.getConfiguredRegions()) {
 
-         PolicyApi policyApi = api.getPolicyApiForZoneAndGroup(zone, created.get(zone).get(0).getId());
+         PolicyApi policyApi = api.getPolicyApi(region, created.get(region).get(0).getId());
 
          FluentIterable<ScalingPolicy> scalingPolicyResponse = policyApi.list();
          assertNotNull(scalingPolicyResponse.iterator().next().getId());
@@ -235,9 +235,9 @@ public class ScalingPolicyApiLiveTest extends BaseAutoscaleApiLiveTest {
 
    @Test
    public void testGetPolicy() {
-      for (String zone : api.getConfiguredZones()) {
+      for (String region : api.getConfiguredRegions()) {
 
-         PolicyApi policyApi = api.getPolicyApiForZoneAndGroup(zone, created.get(zone).get(0).getId());
+         PolicyApi policyApi = api.getPolicyApi(region, created.get(region).get(0).getId());
 
          assertNotNull(policyApi);
          ScalingPolicy listResponse = policyApi.list().iterator().next();
@@ -254,9 +254,9 @@ public class ScalingPolicyApiLiveTest extends BaseAutoscaleApiLiveTest {
 
    @Test
    public void testUpdatePolicy() {
-      for (String zone : api.getConfiguredZones()) {
+      for (String region : api.getConfiguredRegions()) {
 
-         PolicyApi policyApi = api.getPolicyApiForZoneAndGroup(zone, created.get(zone).get(0).getId());
+         PolicyApi policyApi = api.getPolicyApi(region, created.get(region).get(0).getId());
 
          List<CreateScalingPolicy> scalingPolicies = Lists.newArrayList();
 
@@ -298,9 +298,9 @@ public class ScalingPolicyApiLiveTest extends BaseAutoscaleApiLiveTest {
 
    @Test
    public void testDeletePolicy() {
-      for (String zone : api.getConfiguredZones()) {
+      for (String region : api.getConfiguredRegions()) {
 
-         PolicyApi policyApi = api.getPolicyApiForZoneAndGroup(zone, created.get(zone).get(0).getId());
+         PolicyApi policyApi = api.getPolicyApi(region, created.get(region).get(0).getId());
 
          List<CreateScalingPolicy> scalingPolicies = Lists.newArrayList();
 
@@ -311,7 +311,7 @@ public class ScalingPolicyApiLiveTest extends BaseAutoscaleApiLiveTest {
                .targetType(ScalingPolicyTargetType.INCREMENTAL)
                .target("1")
                .build();
-         scalingPolicies.add(scalingPolicy);         
+         scalingPolicies.add(scalingPolicy);
 
          FluentIterable<ScalingPolicy> scalingPolicyResponse = policyApi.create(scalingPolicies);
          String policyId = scalingPolicyResponse.iterator().next().getId();
@@ -324,9 +324,9 @@ public class ScalingPolicyApiLiveTest extends BaseAutoscaleApiLiveTest {
 
    @Test
    public void testExecutePolicy() {
-      for (String zone : api.getConfiguredZones()) {
+      for (String region : api.getConfiguredRegions()) {
 
-         PolicyApi policyApi = api.getPolicyApiForZoneAndGroup(zone, created.get(zone).get(0).getId());
+         PolicyApi policyApi = api.getPolicyApi(region, created.get(region).get(0).getId());
 
          List<CreateScalingPolicy> scalingPolicies = Lists.newArrayList();
 
@@ -337,7 +337,7 @@ public class ScalingPolicyApiLiveTest extends BaseAutoscaleApiLiveTest {
                .targetType(ScalingPolicyTargetType.INCREMENTAL)
                .target("1")
                .build();
-         scalingPolicies.add(scalingPolicy);         
+         scalingPolicies.add(scalingPolicy);
 
          FluentIterable<ScalingPolicy> scalingPolicyResponse = policyApi.create(scalingPolicies);
          String policyId = scalingPolicyResponse.iterator().next().getId();
@@ -346,15 +346,15 @@ public class ScalingPolicyApiLiveTest extends BaseAutoscaleApiLiveTest {
          boolean result = policyApi.execute(policyId);
          assertTrue(result);
       }
-   }   
+   }
 
    @Override
    @AfterClass(groups = { "integration", "live" })
    public void tearDown() {
-      for (String zone : api.getConfiguredZones()) {
-         GroupApi groupApi = api.getGroupApiForZone(zone);
-         for (Group group : created.get(zone)) {
-            PolicyApi policyApi = api.getPolicyApiForZoneAndGroup(zone, group.getId());
+      for (String region : api.getConfiguredRegions()) {
+         GroupApi groupApi = api.getGroupApi(region);
+         for (Group group : created.get(region)) {
+            PolicyApi policyApi = api.getPolicyApi(region, group.getId());
             if (policyApi == null)
                 continue;
             for (ScalingPolicy sgr : policyApi.list()) {

--- a/rackspace-autoscale/src/test/java/org/jclouds/rackspace/autoscale/v1/features/ScalingPolicyApiMockTest.java
+++ b/rackspace-autoscale/src/test/java/org/jclouds/rackspace/autoscale/v1/features/ScalingPolicyApiMockTest.java
@@ -52,7 +52,7 @@ public class ScalingPolicyApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         PolicyApi api = autoscaleApi.getPolicyApiForZoneAndGroup("DFW", "groupId1");         
+         PolicyApi api = autoscaleApi.getPolicyApi("DFW", "groupId1");
 
          List<CreateScalingPolicy> scalingPolicies = Lists.newArrayList();
 
@@ -95,7 +95,7 @@ public class ScalingPolicyApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         PolicyApi api = autoscaleApi.getPolicyApiForZoneAndGroup("DFW", "groupId1");         
+         PolicyApi api = autoscaleApi.getPolicyApi("DFW", "groupId1");
 
          List<CreateScalingPolicy> scalingPolicies = Lists.newArrayList();
 
@@ -132,7 +132,7 @@ public class ScalingPolicyApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         PolicyApi api = autoscaleApi.getPolicyApiForZoneAndGroup("DFW", "groupId1");         
+         PolicyApi api = autoscaleApi.getPolicyApi("DFW", "groupId1");
 
          List<CreateScalingPolicy> scalingPolicies = Lists.newArrayList();
 
@@ -179,7 +179,7 @@ public class ScalingPolicyApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         PolicyApi api = autoscaleApi.getPolicyApiForZoneAndGroup("DFW", "groupId1");         
+         PolicyApi api = autoscaleApi.getPolicyApi("DFW", "groupId1");
 
          List<CreateScalingPolicy> scalingPolicies = Lists.newArrayList();
 
@@ -226,7 +226,7 @@ public class ScalingPolicyApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         PolicyApi api = autoscaleApi.getPolicyApiForZoneAndGroup("DFW", "groupId1");         
+         PolicyApi api = autoscaleApi.getPolicyApi("DFW", "groupId1");
 
          FluentIterable<ScalingPolicy> scalingPolicyResponse = api.list();
 
@@ -258,7 +258,7 @@ public class ScalingPolicyApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         PolicyApi api = autoscaleApi.getPolicyApiForZoneAndGroup("DFW", "groupId1");         
+         PolicyApi api = autoscaleApi.getPolicyApi("DFW", "groupId1");
 
          FluentIterable<ScalingPolicy> scalingPolicyResponse = api.list();
 
@@ -284,7 +284,7 @@ public class ScalingPolicyApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         PolicyApi api = autoscaleApi.getPolicyApiForZoneAndGroup("DFW", "groupId1");         
+         PolicyApi api = autoscaleApi.getPolicyApi("DFW", "groupId1");
 
          ScalingPolicy scalingPolicyResponse = api.get("policyId");
 
@@ -315,7 +315,7 @@ public class ScalingPolicyApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         PolicyApi api = autoscaleApi.getPolicyApiForZoneAndGroup("DFW", "groupId1");         
+         PolicyApi api = autoscaleApi.getPolicyApi("DFW", "groupId1");
 
          ScalingPolicy scalingPolicyResponse = api.get("policyId");
 
@@ -341,7 +341,7 @@ public class ScalingPolicyApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         PolicyApi api = autoscaleApi.getPolicyApiForZoneAndGroup("DFW", "groupId1");
+         PolicyApi api = autoscaleApi.getPolicyApi("DFW", "groupId1");
 
          CreateScalingPolicy scalingPolicy = CreateScalingPolicy.builder()
                .cooldown(6)
@@ -375,7 +375,7 @@ public class ScalingPolicyApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         PolicyApi api = autoscaleApi.getPolicyApiForZoneAndGroup("DFW", "groupId1");
+         PolicyApi api = autoscaleApi.getPolicyApi("DFW", "groupId1");
 
          CreateScalingPolicy scalingPolicy = CreateScalingPolicy.builder()
                .cooldown(6)
@@ -409,7 +409,7 @@ public class ScalingPolicyApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         PolicyApi api = autoscaleApi.getPolicyApiForZoneAndGroup("DFW", "groupId1");
+         PolicyApi api = autoscaleApi.getPolicyApi("DFW", "groupId1");
 
          boolean result = api.delete("policyId");
 
@@ -435,7 +435,7 @@ public class ScalingPolicyApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         PolicyApi api = autoscaleApi.getPolicyApiForZoneAndGroup("DFW", "groupId1");
+         PolicyApi api = autoscaleApi.getPolicyApi("DFW", "groupId1");
 
          boolean result = api.delete("policyId");
 
@@ -461,7 +461,7 @@ public class ScalingPolicyApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         PolicyApi api = autoscaleApi.getPolicyApiForZoneAndGroup("DFW", "groupId1");
+         PolicyApi api = autoscaleApi.getPolicyApi("DFW", "groupId1");
 
          boolean result = api.execute("policyId");
 
@@ -487,7 +487,7 @@ public class ScalingPolicyApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         PolicyApi api = autoscaleApi.getPolicyApiForZoneAndGroup("DFW", "groupId1");
+         PolicyApi api = autoscaleApi.getPolicyApi("DFW", "groupId1");
 
          boolean result = api.execute("policyId");
 

--- a/rackspace-autoscale/src/test/java/org/jclouds/rackspace/autoscale/v1/features/WebhookApiMockTest.java
+++ b/rackspace-autoscale/src/test/java/org/jclouds/rackspace/autoscale/v1/features/WebhookApiMockTest.java
@@ -48,7 +48,7 @@ public class WebhookApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         WebhookApi api = autoscaleApi.getWebhookApiForZoneAndGroupAndPolicy("DFW", "1234567890", "321456");         
+         WebhookApi api = autoscaleApi.getWebhookApi("DFW", "1234567890", "321456");
 
          FluentIterable<Webhook> webhooks = api.create("PagerDuty", ImmutableMap.<String, Object>of("notes", "PagerDuty will fire this webhook"));
 
@@ -75,7 +75,7 @@ public class WebhookApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         WebhookApi api = autoscaleApi.getWebhookApiForZoneAndGroupAndPolicy("DFW", "1234567890", "321456");         
+         WebhookApi api = autoscaleApi.getWebhookApi("DFW", "1234567890", "321456");
 
          FluentIterable<Webhook> webhooks = api.create("PagerDuty", ImmutableMap.<String, Object>of("notes", "PagerDuty will fire this webhook"));
 
@@ -101,7 +101,7 @@ public class WebhookApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         WebhookApi api = autoscaleApi.getWebhookApiForZoneAndGroupAndPolicy("DFW", "1234567890", "321456");         
+         WebhookApi api = autoscaleApi.getWebhookApi("DFW", "1234567890", "321456");
 
          FluentIterable<Webhook> webhooks = api.create(ImmutableList.of(
                CreateWebhook.builder().name("PagerDuty").metadata(ImmutableMap.<String, Object>of("notes", "PagerDuty will fire this webhook")).build(),
@@ -132,7 +132,7 @@ public class WebhookApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         WebhookApi api = autoscaleApi.getWebhookApiForZoneAndGroupAndPolicy("DFW", "1234567890", "321456");         
+         WebhookApi api = autoscaleApi.getWebhookApi("DFW", "1234567890", "321456");
 
          FluentIterable<Webhook> webhooks = api.create(ImmutableList.of(
                CreateWebhook.builder().name("PagerDuty").metadata(ImmutableMap.<String, Object>of("notes", "PagerDuty will fire this webhook")).build(),
@@ -161,7 +161,7 @@ public class WebhookApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         WebhookApi api = autoscaleApi.getWebhookApiForZoneAndGroupAndPolicy("DFW", "1234567890", "321456");         
+         WebhookApi api = autoscaleApi.getWebhookApi("DFW", "1234567890", "321456");
 
          FluentIterable<Webhook> webhooks = api.list();
 
@@ -189,7 +189,7 @@ public class WebhookApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         WebhookApi api = autoscaleApi.getWebhookApiForZoneAndGroupAndPolicy("DFW", "1234567890", "321456");         
+         WebhookApi api = autoscaleApi.getWebhookApi("DFW", "1234567890", "321456");
 
          FluentIterable<Webhook> webhooks = api.list();
 
@@ -215,7 +215,7 @@ public class WebhookApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         WebhookApi api = autoscaleApi.getWebhookApiForZoneAndGroupAndPolicy("DFW", "1234567890", "321456");         
+         WebhookApi api = autoscaleApi.getWebhookApi("DFW", "1234567890", "321456");
 
          boolean success = api.update("5555", "alice", ImmutableMap.<String, Object>of("notes", "this is for Alice"));
 
@@ -241,7 +241,7 @@ public class WebhookApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         WebhookApi api = autoscaleApi.getWebhookApiForZoneAndGroupAndPolicy("DFW", "1234567890", "321456");         
+         WebhookApi api = autoscaleApi.getWebhookApi("DFW", "1234567890", "321456");
 
          boolean success = api.update("5555", "alice", ImmutableMap.<String, Object>of("notes", "this is for Alice"));
 
@@ -267,7 +267,7 @@ public class WebhookApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         WebhookApi api = autoscaleApi.getWebhookApiForZoneAndGroupAndPolicy("DFW", "1234567890", "321456");         
+         WebhookApi api = autoscaleApi.getWebhookApi("DFW", "1234567890", "321456");
 
          Webhook webhook = api.get("5555");
 
@@ -294,7 +294,7 @@ public class WebhookApiMockTest extends BaseAutoscaleApiMockTest {
 
       try {
          AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
-         WebhookApi api = autoscaleApi.getWebhookApiForZoneAndGroupAndPolicy("DFW", "1234567890", "321456");         
+         WebhookApi api = autoscaleApi.getWebhookApi("DFW", "1234567890", "321456");
 
          Webhook webhook = api.get("5555");
 

--- a/rackspace-cloudbigdata-us/README.md
+++ b/rackspace-cloudbigdata-us/README.md
@@ -1,7 +1,7 @@
 Rackspace Cloud Auto Scale US
 =============================
 
-The Rackspace Cloud Big Data Provider for the US zones.
+The Rackspace Cloud Big Data Provider for the US region.
 
 Production ready?
 No

--- a/rackspace-cloudbigdata-us/src/main/java/org/jclouds/rackspace/cloudbigdata/us/v1/CloudBigDataUSProviderMetadata.java
+++ b/rackspace-cloudbigdata-us/src/main/java/org/jclouds/rackspace/cloudbigdata/us/v1/CloudBigDataUSProviderMetadata.java
@@ -17,15 +17,15 @@
 package org.jclouds.rackspace.cloudbigdata.us.v1;
 
 import static org.jclouds.location.reference.LocationConstants.ISO3166_CODES;
-import static org.jclouds.location.reference.LocationConstants.PROPERTY_ZONE;
-import static org.jclouds.location.reference.LocationConstants.PROPERTY_ZONES;
+import static org.jclouds.location.reference.LocationConstants.PROPERTY_REGION;
+import static org.jclouds.location.reference.LocationConstants.PROPERTY_REGIONS;
 import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.CREDENTIAL_TYPE;
 import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.SERVICE_TYPE;
 
 import java.net.URI;
 import java.util.Properties;
 
-import org.jclouds.openstack.keystone.v2_0.config.KeystoneAuthenticationModule.ZoneModule;
+import org.jclouds.openstack.keystone.v2_0.config.KeystoneAuthenticationModule.RegionModule;
 import org.jclouds.providers.ProviderMetadata;
 import org.jclouds.providers.internal.BaseProviderMetadata;
 import org.jclouds.rackspace.cloudbigdata.v1.CloudBigDataApiMetadata;
@@ -77,12 +77,12 @@ public class CloudBigDataUSProviderMetadata extends BaseProviderMetadata {
    public static Properties defaultProperties() {
       Properties properties = new Properties();
       properties.setProperty(CREDENTIAL_TYPE, CloudIdentityCredentialTypes.API_KEY_CREDENTIALS);
-      properties.setProperty(SERVICE_TYPE, ServiceType.BIG_DATA); 
-      //properties.setProperty(PROPERTY_ZONES, "ORD,DFW,SYD");
-      properties.setProperty(PROPERTY_ZONES, "ORD");
-      properties.setProperty(PROPERTY_ZONE + ".ORD." + ISO3166_CODES, "US-IL");
-      //properties.setProperty(PROPERTY_ZONE + ".DFW." + ISO3166_CODES, "US-TX");
-      //properties.setProperty(PROPERTY_ZONE + ".SYD." + ISO3166_CODES, "AU-NSW");
+      properties.setProperty(SERVICE_TYPE, ServiceType.BIG_DATA);
+      //properties.setProperty(PROPERTY_REGIONS, "ORD,DFW,SYD");
+      properties.setProperty(PROPERTY_REGIONS, "ORD");
+      properties.setProperty(PROPERTY_REGION + ".ORD." + ISO3166_CODES, "US-IL");
+      //properties.setProperty(PROPERTY_REGION + ".DFW." + ISO3166_CODES, "US-TX");
+      //properties.setProperty(PROPERTY_REGION + ".SYD." + ISO3166_CODES, "AU-NSW");
       return properties;
    }
 
@@ -103,7 +103,7 @@ public class CloudBigDataUSProviderMetadata extends BaseProviderMetadata {
                .defaultModules(ImmutableSet.<Class<? extends Module>>builder()
                      .add(CloudIdentityAuthenticationApiModule.class)
                      .add(CloudIdentityAuthenticationModule.class)
-                     .add(ZoneModule.class)
+                     .add(RegionModule.class)
                      .add(CloudBigDataParserModule.class)
                      .add(CloudBigDataHttpApiModule.class).build())
                      .build())

--- a/rackspace-cloudbigdata/src/main/java/org/jclouds/rackspace/cloudbigdata/v1/CloudBigDataApi.java
+++ b/rackspace-cloudbigdata/src/main/java/org/jclouds/rackspace/cloudbigdata/v1/CloudBigDataApi.java
@@ -20,8 +20,8 @@ import java.io.Closeable;
 import java.util.Set;
 
 import org.jclouds.javax.annotation.Nullable;
-import org.jclouds.location.Zone;
-import org.jclouds.location.functions.ZoneToEndpoint;
+import org.jclouds.location.Region;
+import org.jclouds.location.functions.RegionToEndpoint;
 import org.jclouds.rackspace.cloudbigdata.v1.features.ClusterApi;
 import org.jclouds.rackspace.cloudbigdata.v1.features.ProfileApi;
 import org.jclouds.rest.annotations.Delegate;
@@ -30,33 +30,64 @@ import org.jclouds.rest.annotations.EndpointParam;
 import com.google.inject.Provides;
 
 /**
- * Provides access to Rackspace Cloud Big Data.
- * Rackspace Cloud Big Data is an on-demand Apache Hadoop service on the Rackspace open cloud. The service supports a RESTful API and alleviates the pain associated with deploying, managing, and scaling Hadoop clusters.
- * @see <a href="http://docs.rackspace.com/cbd/api/v1.0/cbd-devguide/content/overview.html">API Doc</a>
+ * Provides access to the Rackspace Cloud Big Data v1 API.
+ *
+ * Rackspace Cloud Big Data is an on-demand Apache Hadoop service on the Rackspace open cloud. The service
+ * supports a RESTful API and alleviates the pain associated with deploying, managing, and scaling Hadoop clusters.
  */
-public interface CloudBigDataApi extends Closeable{
+public interface CloudBigDataApi extends Closeable {
    /**
-    * Provides a set of all zones available.
-    * 
-    * @return the Zone codes configured
+    * Provides a set of all regions available.
+    *
+    * @return the Region codes configured
     */
    @Provides
-   @Zone
+   @Region
+   Set<String> getConfiguredRegions();
+
+   /**
+    * Provides access to all Profile features.
+    * @param region The region for the profile API.
+    * @return A profile API context.
+    */
+   @Delegate
+   ProfileApi getProfileApi(@EndpointParam(parser = RegionToEndpoint.class) @Nullable String region);
+
+   /**
+    * Provides access to all Cluster features.
+    * @param region The region for the profile API.
+    * @return A cluster API context.
+    */
+   @Delegate
+   ClusterApi getClusterApi(@EndpointParam(parser = RegionToEndpoint.class) @Nullable String region);
+
+   /**
+    * @return the Zone codes configured
+    * @deprecated Please use {@link #getConfiguredRegions()} as this method will be removed in jclouds 3.0.
+    */
+   @Deprecated
+   @Provides
+   @Region
    Set<String> getConfiguredZones();
 
    /**
     * Provides access to all Profile features.
     * @param zone The zone (region) for the profile API.
     * @return A profile API context.
+    * @deprecated Please use {@link #getProfileApi(String)} as this method will be removed in jclouds 3.0.
     */
+   @Deprecated
    @Delegate
-   ProfileApi getProfileApiForZone(@EndpointParam(parser = ZoneToEndpoint.class) @Nullable String zone);
+   ProfileApi getProfileApiForZone(@EndpointParam(parser = RegionToEndpoint.class) @Nullable String zone);
 
    /**
     * Provides access to all Cluster features.
     * @param zone The zone (region) for the profile API.
     * @return A cluster API context.
+    * @deprecated Please use {@link #getClusterApi(String)} as this method will be removed in jclouds 3.0.
     */
+   @Deprecated
    @Delegate
-   ClusterApi getClusterApiForZone(@EndpointParam(parser = ZoneToEndpoint.class) @Nullable String zone);
+   ClusterApi getClusterApiForZone(@EndpointParam(parser = RegionToEndpoint.class) @Nullable String zone);
+
 }

--- a/rackspace-cloudbigdata/src/main/java/org/jclouds/rackspace/cloudbigdata/v1/CloudBigDataApiMetadata.java
+++ b/rackspace-cloudbigdata/src/main/java/org/jclouds/rackspace/cloudbigdata/v1/CloudBigDataApiMetadata.java
@@ -23,7 +23,7 @@ import java.net.URI;
 import java.util.Properties;
 
 import org.jclouds.openstack.keystone.v2_0.config.CredentialTypes;
-import org.jclouds.openstack.keystone.v2_0.config.KeystoneAuthenticationModule.ZoneModule;
+import org.jclouds.openstack.keystone.v2_0.config.KeystoneAuthenticationModule.RegionModule;
 import org.jclouds.rackspace.cloudbigdata.v1.config.CloudBigDataHttpApiModule;
 import org.jclouds.rackspace.cloudbigdata.v1.config.CloudBigDataParserModule;
 import org.jclouds.rackspace.cloudidentity.v2_0.ServiceType;
@@ -35,8 +35,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.inject.Module;
 
 /**
- * Implementation of {@link ApiMetadata} for the Rackspace Cloud Big Data API
- * 
+ * Implementation of {@link org.jclouds.apis.ApiMetadata} for the Rackspace Cloud Big Data API
+ *
  * @see CloudBigDataApi
  */
 public class CloudBigDataApiMetadata extends BaseHttpApiMetadata<CloudBigDataApi> {
@@ -47,7 +47,7 @@ public class CloudBigDataApiMetadata extends BaseHttpApiMetadata<CloudBigDataApi
    }
 
    /**
-    * 
+    *
     */
    public CloudBigDataApiMetadata() {
       this(new Builder());
@@ -69,7 +69,7 @@ public class CloudBigDataApiMetadata extends BaseHttpApiMetadata<CloudBigDataApi
     */
    public static class Builder extends BaseHttpApiMetadata.Builder<CloudBigDataApi, Builder> {
 
-      protected Builder() {   
+      protected Builder() {
          id("rackspace-cloudbigdata")
          .name("Rackspace Cloud Big Data API")
          .identityName("${tenantName}:${userName} or ${userName}, if your keystone supports a default tenant")
@@ -82,7 +82,7 @@ public class CloudBigDataApiMetadata extends BaseHttpApiMetadata<CloudBigDataApi
          .defaultModules(ImmutableSet.<Class<? extends Module>>builder()
                .add(CloudIdentityAuthenticationApiModule.class)
                .add(CloudIdentityAuthenticationModule.class)
-               .add(ZoneModule.class)
+               .add(RegionModule.class)
                .add(CloudBigDataParserModule.class)
                .add(CloudBigDataHttpApiModule.class)
                .build());

--- a/rackspace-cloudbigdata/src/main/java/org/jclouds/rackspace/cloudbigdata/v1/features/ClusterApi.java
+++ b/rackspace-cloudbigdata/src/main/java/org/jclouds/rackspace/cloudbigdata/v1/features/ClusterApi.java
@@ -25,11 +25,11 @@ import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 import org.jclouds.Fallbacks.EmptyFluentIterableOnNotFoundOr404;
 import org.jclouds.Fallbacks.NullOnNotFoundOr404;
+import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.openstack.keystone.v2_0.filters.AuthenticateRequest;
 import org.jclouds.rackspace.cloudbigdata.v1.domain.Cluster;
 import org.jclouds.rackspace.cloudbigdata.v1.domain.CreateCluster;
@@ -47,7 +47,8 @@ import com.google.common.collect.FluentIterable;
  */
 @RequestFilters(AuthenticateRequest.class)
 @Consumes(MediaType.APPLICATION_JSON)
-@Produces(MediaType.APPLICATION_JSON)
+//@Produces(MediaType.APPLICATION_JSON)
+@Path("/clusters")
 public interface ClusterApi extends Closeable {
 
    /**
@@ -58,51 +59,52 @@ public interface ClusterApi extends Closeable {
     * @see Cluster
     * @see CreateCluster
     */
-   @Named("Cluster:create")
+   @Named("cluster:create")
    @POST
-   @Path("/clusters")
-   @Fallback(NullOnNotFoundOr404.class)
    @SelectJson("cluster")
+   @Fallback(NullOnNotFoundOr404.class)
+   @Nullable
    Cluster create(@WrapWith("cluster") CreateCluster cluster);
-   
+
    /**
     * List all clusters.
     * @return A list containing information about all the clusters.
     * @see Cluster
     */
-   @Named("Cluster:list")
+   @Named("cluster:list")
    @GET
-   @Path("/clusters")
-   @Fallback(EmptyFluentIterableOnNotFoundOr404.class)
    @SelectJson("clusters")
+   @Fallback(EmptyFluentIterableOnNotFoundOr404.class)
    FluentIterable<Cluster> list();
-   
+
    /**
     * Get information about a specific cluster.
     * @param clusterId The id of the cluster queried.
     * @return Detailed information about a specific cluster.
     * @see Cluster
     */
-   @Named("Cluster:get")
+   @Named("cluster:get")
    @GET
-   @Path("/clusters/{clusterId}")
-   @Fallback(NullOnNotFoundOr404.class)
+   @Path("/{clusterId}")
    @SelectJson("cluster")
+   @Fallback(NullOnNotFoundOr404.class)
+   @Nullable
    Cluster get(@PathParam("clusterId") String clusterId);
-   
+
    /**
     * Delete a cluster.
     * @param clusterId The id of the cluster to be deleted.
     * @return Detailed information about the cluster to be deleted.
     * @see Cluster
     */
-   @Named("Cluster:delete")
+   @Named("cluster:delete")
    @DELETE
-   @Path("/clusters/{clusterId}")
-   @Fallback(NullOnNotFoundOr404.class)
+   @Path("/{clusterId}")
    @SelectJson("cluster")
+   @Fallback(NullOnNotFoundOr404.class)
+   @Nullable
    Cluster delete(@PathParam("clusterId") String clusterId);
-   
+
    /**
     * Resize a cluster. Changes the number of nodes for this cluster.
     * @param clusterId The id of the cluster to be deleted.
@@ -110,11 +112,12 @@ public interface ClusterApi extends Closeable {
     * @return Detailed information about the cluster to be resized.
     * @see Cluster
     */
-   @Named("Cluster:resize")
+   @Named("cluster:resize")
    @POST
-   @Path("/clusters/{clusterId}/action")
+   @Path("/{clusterId}/action")
    @WrapWith("resize")
-   @Fallback(NullOnNotFoundOr404.class)
    @SelectJson("cluster")
+   @Fallback(NullOnNotFoundOr404.class)
+   @Nullable
    Cluster resize(@PathParam("clusterId") String clusterId, @PayloadParam("nodeCount") int nodeCount);
 }

--- a/rackspace-cloudbigdata/src/main/java/org/jclouds/rackspace/cloudbigdata/v1/features/ProfileApi.java
+++ b/rackspace-cloudbigdata/src/main/java/org/jclouds/rackspace/cloudbigdata/v1/features/ProfileApi.java
@@ -23,10 +23,10 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 import org.jclouds.Fallbacks.NullOnNotFoundOr404;
+import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.openstack.keystone.v2_0.filters.AuthenticateRequest;
 import org.jclouds.rackspace.cloudbigdata.v1.domain.CreateProfile;
 import org.jclouds.rackspace.cloudbigdata.v1.domain.Profile;
@@ -44,7 +44,8 @@ import org.jclouds.rest.annotations.WrapWith;
  */
 @RequestFilters(AuthenticateRequest.class)
 @Consumes(MediaType.APPLICATION_JSON)
-@Produces(MediaType.APPLICATION_JSON)
+//@Produces(MediaType.APPLICATION_JSON)
+@Path("/profile")
 public interface ProfileApi extends Closeable {
 
    /**
@@ -55,13 +56,13 @@ public interface ProfileApi extends Closeable {
     * @see Profile
     * @see CreateProfile
     */
-   @Named("Profile:create")
+   @Named("profile:create")
    @POST
-   @Path("/profile")
-   @Fallback(NullOnNotFoundOr404.class)
    @SelectJson("profile")
+   @Fallback(NullOnNotFoundOr404.class)
+   @Nullable
    Profile create(@WrapWith("profile") CreateProfile profile);
-   
+
    /**
     * This operation returns detailed profile information for the current user.
     * Before creating a cluster, a profile has to be created.
@@ -69,10 +70,10 @@ public interface ProfileApi extends Closeable {
     * @see Profile
     * @see CreateProfile
     */
-   @Named("Profile:get")
+   @Named("profile:get")
    @GET
-   @Path("/profile")
-   @Fallback(NullOnNotFoundOr404.class)
    @SelectJson("profile")
+   @Fallback(NullOnNotFoundOr404.class)
+   @Nullable
    Profile get();
 }

--- a/rackspace-cloudbigdata/src/main/java/org/jclouds/rackspace/cloudbigdata/v1/predicates/ClusterPredicates.java
+++ b/rackspace-cloudbigdata/src/main/java/org/jclouds/rackspace/cloudbigdata/v1/predicates/ClusterPredicates.java
@@ -35,24 +35,24 @@ import com.google.common.base.Predicate;
  * <pre>
  * {@code
  * Cluster Cluster = ClusterApi.create(100);
- * 
+ *
  * RetryablePredicate<String> awaitAvailable = RetryablePredicate.create(
  *    ClusterPredicates.available(ClusterApi), 600, 10, 10, TimeUnit.SECONDS);
- * 
+ *
  * if (!awaitAvailable.apply(Cluster.getId())) {
- *    throw new TimeoutException("Timeout on Cluster: " + Cluster); 
- * }    
+ *    throw new TimeoutException("Timeout on Cluster: " + Cluster);
+ * }
  * }
  * </pre>
- * 
+ *
  * You can also use the static convenience methods as follows.
- * 
+ *
  * <pre>
  * {@code
  * Cluster Cluster = ClusterApi.create(100);
- * 
+ *
  * if (!ClusterPredicates.awaitAvailable(ClusterApi).apply(Cluster.getId())) {
- *    throw new TimeoutException("Timeout on Cluster: " + Cluster);     
+ *    throw new TimeoutException("Timeout on Cluster: " + Cluster);
  * }
  * }
  * </pre>
@@ -60,8 +60,8 @@ import com.google.common.base.Predicate;
 public class ClusterPredicates {
    /**
     * Wait until an Cluster is Available.
-    * 
-    * @param clusterApi The ClusterApi in the zone where your Cluster resides.
+    *
+    * @param clusterApi The ClusterApi in the region where your Cluster resides.
     * @return RetryablePredicate That will check the status every 5 seconds for a maxiumum of 10 minutes.
     */
    public static Predicate<Cluster> awaitAvailable(ClusterApi clusterApi) {
@@ -71,8 +71,8 @@ public class ClusterPredicates {
 
    /**
     * Wait until an Cluster no longer exists.
-    * 
-    * @param clusterApi The ClusterApi in the zone where your Cluster resides.
+    *
+    * @param clusterApi The ClusterApi in the region where your Cluster resides.
     * @return RetryablePredicate That will check whether the Cluster exists.
     * every 5 seconds for a maximum of 10 minutes.
     */
@@ -80,11 +80,11 @@ public class ClusterPredicates {
       DeletedPredicate deletedPredicate = new DeletedPredicate(clusterApi);
       return retry(deletedPredicate, 600, 5, 5, SECONDS);
    }
-   
+
    /**
     * Wait until Cluster is in the status specified.
-    * 
-    * @param clusterApi The ClusterApi in the zone where your Cluster resides.
+    *
+    * @param clusterApi The ClusterApi in the region where your Cluster resides.
     * @param status Wait until Cluster in in this status.
     * @param maxWaitInSec Maximum time to wait.
     * @param periodInSec Interval between retries.
@@ -95,7 +95,7 @@ public class ClusterPredicates {
       StatusUpdatedPredicate statusPredicate = new StatusUpdatedPredicate(clusterApi, status);
       return retry(statusPredicate, maxWaitInSec, periodInSec, periodInSec, SECONDS);
    }
-   
+
    private static class StatusUpdatedPredicate implements Predicate<Cluster> {
       private ClusterApi clusterApi;
       private Status status;
@@ -111,14 +111,14 @@ public class ClusterPredicates {
       @Override
       public boolean apply(Cluster cluster) {
          checkNotNull(cluster, "Cluster must be defined");
-         
+
          if (status.equals(cluster.getStatus())) {
             return true;
          }
          else {
             Cluster ClusterUpdated = clusterApi.get(cluster.getId());
             checkNotNull(ClusterUpdated, "Cluster %s not found.", cluster.getId());
-            
+
             return status.equals(ClusterUpdated.getStatus());
          }
       }

--- a/rackspace-cloudbigdata/src/test/java/org/jclouds/rackspace/cloudbigdata/v1/features/ClusterApiMockTest.java
+++ b/rackspace-cloudbigdata/src/test/java/org/jclouds/rackspace/cloudbigdata/v1/features/ClusterApiMockTest.java
@@ -50,7 +50,7 @@ public class ClusterApiMockTest extends BaseCloudBigDataApiMockTest {
 
       try {
          CloudBigDataApi cbdApi = api(server.getUrl("/").toString(), "rackspace-cloudbigdata", overrides);
-         ClusterApi api = cbdApi.getClusterApiForZone("ORD");
+         ClusterApi api = cbdApi.getClusterApi("ORD");
 
          CreateCluster createCluster = CreateCluster.builder()
                .name("slice")
@@ -96,7 +96,7 @@ public class ClusterApiMockTest extends BaseCloudBigDataApiMockTest {
 
       try {
          CloudBigDataApi cbdApi = api(server.getUrl("/").toString(), "rackspace-cloudbigdata", overrides);
-         ClusterApi api = cbdApi.getClusterApiForZone("ORD");
+         ClusterApi api = cbdApi.getClusterApi("ORD");
 
          CreateCluster createCluster = CreateCluster.builder()
                .name("slice")
@@ -130,7 +130,7 @@ public class ClusterApiMockTest extends BaseCloudBigDataApiMockTest {
 
       try {
          CloudBigDataApi cbdApi = api(server.getUrl("/").toString(), "rackspace-cloudbigdata", overrides);
-         ClusterApi api = cbdApi.getClusterApiForZone("ORD");         
+         ClusterApi api = cbdApi.getClusterApi("ORD");
 
          Cluster cluster = api.get("5");
 
@@ -168,7 +168,7 @@ public class ClusterApiMockTest extends BaseCloudBigDataApiMockTest {
 
       try {
          CloudBigDataApi cbdApi = api(server.getUrl("/").toString(), "rackspace-cloudbigdata", overrides);
-         ClusterApi api = cbdApi.getClusterApiForZone("ORD");         
+         ClusterApi api = cbdApi.getClusterApi("ORD");
 
          Cluster cluster = api.get("5");
 
@@ -194,7 +194,7 @@ public class ClusterApiMockTest extends BaseCloudBigDataApiMockTest {
 
       try {
          CloudBigDataApi cbdApi = api(server.getUrl("/").toString(), "rackspace-cloudbigdata", overrides);
-         ClusterApi api = cbdApi.getClusterApiForZone("ORD");         
+         ClusterApi api = cbdApi.getClusterApi("ORD");
 
          FluentIterable<Cluster> clusters = api.list();
 
@@ -234,7 +234,7 @@ public class ClusterApiMockTest extends BaseCloudBigDataApiMockTest {
 
       try {
          CloudBigDataApi cbdApi = api(server.getUrl("/").toString(), "rackspace-cloudbigdata", overrides);
-         ClusterApi api = cbdApi.getClusterApiForZone("ORD");         
+         ClusterApi api = cbdApi.getClusterApi("ORD");
 
          FluentIterable<Cluster> clusters = api.list();
 
@@ -261,7 +261,7 @@ public class ClusterApiMockTest extends BaseCloudBigDataApiMockTest {
 
       try {
          CloudBigDataApi cbdApi = api(server.getUrl("/").toString(), "rackspace-cloudbigdata", overrides);
-         ClusterApi api = cbdApi.getClusterApiForZone("ORD");         
+         ClusterApi api = cbdApi.getClusterApi("ORD");
 
          Cluster cluster = api.delete("5");
 
@@ -299,7 +299,7 @@ public class ClusterApiMockTest extends BaseCloudBigDataApiMockTest {
 
       try {
          CloudBigDataApi cbdApi = api(server.getUrl("/").toString(), "rackspace-cloudbigdata", overrides);
-         ClusterApi api = cbdApi.getClusterApiForZone("ORD");         
+         ClusterApi api = cbdApi.getClusterApi("ORD");
 
          Cluster cluster = api.delete("5");
 
@@ -325,7 +325,7 @@ public class ClusterApiMockTest extends BaseCloudBigDataApiMockTest {
 
       try {
          CloudBigDataApi cbdApi = api(server.getUrl("/").toString(), "rackspace-cloudbigdata", overrides);
-         ClusterApi api = cbdApi.getClusterApiForZone("ORD");         
+         ClusterApi api = cbdApi.getClusterApi("ORD");
 
          Cluster cluster = api.resize("5", 10);
 
@@ -363,7 +363,7 @@ public class ClusterApiMockTest extends BaseCloudBigDataApiMockTest {
 
       try {
          CloudBigDataApi cbdApi = api(server.getUrl("/").toString(), "rackspace-cloudbigdata", overrides);
-         ClusterApi api = cbdApi.getClusterApiForZone("ORD");         
+         ClusterApi api = cbdApi.getClusterApi("ORD");
 
          Cluster cluster = api.resize("5", 10);
 

--- a/rackspace-cloudbigdata/src/test/java/org/jclouds/rackspace/cloudbigdata/v1/features/ProfileApiLiveTest.java
+++ b/rackspace-cloudbigdata/src/test/java/org/jclouds/rackspace/cloudbigdata/v1/features/ProfileApiLiveTest.java
@@ -36,14 +36,14 @@ import com.google.common.collect.ImmutableList;
  * Profile live test
  */
 @Test(groups = "live", testName = "ProfileApiLiveTest", singleThreaded = true)
-public class ProfileApiLiveTest extends BaseCloudBigDataApiLiveTest {   
+public class ProfileApiLiveTest extends BaseCloudBigDataApiLiveTest {
 
    @Override
    @BeforeClass(groups = { "integration", "live" })
    public void setup() {
       super.setup();
-      for (String zone : filterZones(api.getConfiguredZones())) {
-         ProfileApi profileApi = api.getProfileApiForZone(zone);
+      for (String region : filterRegions(api.getConfiguredRegions())) {
+         ProfileApi profileApi = api.getProfileApi(region);
 
          CreateProfile createProfile = CreateProfile.builder()
                .username("john.doe")
@@ -67,8 +67,8 @@ public class ProfileApiLiveTest extends BaseCloudBigDataApiLiveTest {
 
    @Test
    public void updateProfile() {
-      for (String zone : filterZones(api.getConfiguredZones())) {
-         ProfileApi profileApi = api.getProfileApiForZone(zone);
+      for (String region : filterRegions(api.getConfiguredRegions())) {
+         ProfileApi profileApi = api.getProfileApi(region);
 
          CreateProfile createProfile = CreateProfile.builder()
                .username("john.doe2")
@@ -88,11 +88,11 @@ public class ProfileApiLiveTest extends BaseCloudBigDataApiLiveTest {
          assertEquals(profile.getCredentialsUsername(), "jdoe");
       }
    }
-      
+
       @Test
       public void getProfile() {
-         for (String zone : filterZones(api.getConfiguredZones())) {
-            ProfileApi profileApi = api.getProfileApiForZone(zone);
+         for (String region : filterRegions(api.getConfiguredRegions())) {
+            ProfileApi profileApi = api.getProfileApi(region);
 
             Profile profile = profileApi.get();
 

--- a/rackspace-cloudbigdata/src/test/java/org/jclouds/rackspace/cloudbigdata/v1/features/ProfileApiMockTest.java
+++ b/rackspace-cloudbigdata/src/test/java/org/jclouds/rackspace/cloudbigdata/v1/features/ProfileApiMockTest.java
@@ -48,17 +48,17 @@ public class ProfileApiMockTest extends BaseCloudBigDataApiMockTest {
 
       try {
          CloudBigDataApi cbdApi = api(server.getUrl("/").toString(), "rackspace-cloudbigdata", overrides);
-         ProfileApi api = cbdApi.getProfileApiForZone("ORD");
+         ProfileApi api = cbdApi.getProfileApi("ORD");
 
          CreateProfile createProfile = CreateProfile.builder()
                .username("john.doe")
                .password("j0Hnd03")
                .sshKeys(ImmutableList.of(ProfileSSHKey.builder().name("t@test")
-                     .publicKey("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCtUFnkFrqDDCgEqW1akQkpMOX\n" + 
-                           "Owwvg73PLn5Z5QgvxjvJhRCg9ZTR/OWXpWcYqFVNagH4Zs8NOb9921TyQ+ydMnatOM\n" + 
-                           "haxMh1ZwTgaUcvndOF8fY+kcERiw1l0iT95w42F8IdUH42Z+8KihZM8gVsbMS6qYTi\n" + 
-                           "OM29WHX7y37wuJIzqf3N2TiVXrqfjwugvY/bZ+47EUn78uk6aPZYJGXdDgaFqnIXUV\n" + 
-                           "N+hRFYXgKnU0Ui0aQkuYwnAW8KmanLoNU2xodrb6/XqWnSAAmwl7aoGKFunQsT6xDW\n" + 
+                     .publicKey("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCtUFnkFrqDDCgEqW1akQkpMOX\n" +
+                           "Owwvg73PLn5Z5QgvxjvJhRCg9ZTR/OWXpWcYqFVNagH4Zs8NOb9921TyQ+ydMnatOM\n" +
+                           "haxMh1ZwTgaUcvndOF8fY+kcERiw1l0iT95w42F8IdUH42Z+8KihZM8gVsbMS6qYTi\n" +
+                           "OM29WHX7y37wuJIzqf3N2TiVXrqfjwugvY/bZ+47EUn78uk6aPZYJGXdDgaFqnIXUV\n" +
+                           "N+hRFYXgKnU0Ui0aQkuYwnAW8KmanLoNU2xodrb6/XqWnSAAmwl7aoGKFunQsT6xDW\n" +
                            "yQk+ncUHUcdofDUqgd3lXmHGrTmQW97vqexDEnhsJ+AwbLGD5dukr t@test")
                            .build()))
                            .credentialsUsername("jdoe")
@@ -97,17 +97,17 @@ public class ProfileApiMockTest extends BaseCloudBigDataApiMockTest {
 
       try {
          CloudBigDataApi cbdApi = api(server.getUrl("/").toString(), "rackspace-cloudbigdata", overrides);
-         ProfileApi api = cbdApi.getProfileApiForZone("ORD");
+         ProfileApi api = cbdApi.getProfileApi("ORD");
 
          CreateProfile createProfile = CreateProfile.builder()
                .username("john.doe")
                .password("j0Hnd03")
                .sshKeys(ImmutableList.of(ProfileSSHKey.builder().name("t@test")
-                     .publicKey("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCtUFnkFrqDDCgEqW1akQkpMOX\n" + 
-                           "Owwvg73PLn5Z5QgvxjvJhRCg9ZTR/OWXpWcYqFVNagH4Zs8NOb9921TyQ+ydMnatOM\n" + 
-                           "haxMh1ZwTgaUcvndOF8fY+kcERiw1l0iT95w42F8IdUH42Z+8KihZM8gVsbMS6qYTi\n" + 
-                           "OM29WHX7y37wuJIzqf3N2TiVXrqfjwugvY/bZ+47EUn78uk6aPZYJGXdDgaFqnIXUV\n" + 
-                           "N+hRFYXgKnU0Ui0aQkuYwnAW8KmanLoNU2xodrb6/XqWnSAAmwl7aoGKFunQsT6xDW\n" + 
+                     .publicKey("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCtUFnkFrqDDCgEqW1akQkpMOX\n" +
+                           "Owwvg73PLn5Z5QgvxjvJhRCg9ZTR/OWXpWcYqFVNagH4Zs8NOb9921TyQ+ydMnatOM\n" +
+                           "haxMh1ZwTgaUcvndOF8fY+kcERiw1l0iT95w42F8IdUH42Z+8KihZM8gVsbMS6qYTi\n" +
+                           "OM29WHX7y37wuJIzqf3N2TiVXrqfjwugvY/bZ+47EUn78uk6aPZYJGXdDgaFqnIXUV\n" +
+                           "N+hRFYXgKnU0Ui0aQkuYwnAW8KmanLoNU2xodrb6/XqWnSAAmwl7aoGKFunQsT6xDW\n" +
                            "yQk+ncUHUcdofDUqgd3lXmHGrTmQW97vqexDEnhsJ+AwbLGD5dukr t@test")
                            .build()))
                            .credentialsUsername("jdoe")
@@ -138,7 +138,7 @@ public class ProfileApiMockTest extends BaseCloudBigDataApiMockTest {
 
       try {
          CloudBigDataApi cbdApi = api(server.getUrl("/").toString(), "rackspace-cloudbigdata", overrides);
-         ProfileApi api = cbdApi.getProfileApiForZone("ORD");
+         ProfileApi api = cbdApi.getProfileApi("ORD");
          Profile profile = api.get();
 
          /*
@@ -171,7 +171,7 @@ public class ProfileApiMockTest extends BaseCloudBigDataApiMockTest {
 
       try {
          CloudBigDataApi cbdApi = api(server.getUrl("/").toString(), "rackspace-cloudbigdata", overrides);
-         ProfileApi api = cbdApi.getProfileApiForZone("ORD");
+         ProfileApi api = cbdApi.getProfileApi("ORD");
          Profile profile = api.get();
 
          /*

--- a/rackspace-cloudfiles/src/main/java/org/jclouds/rackspace/cloudfiles/v1/CloudFilesApi.java
+++ b/rackspace-cloudfiles/src/main/java/org/jclouds/rackspace/cloudfiles/v1/CloudFilesApi.java
@@ -32,7 +32,7 @@ import com.google.common.annotations.Beta;
  * <p/>
  * Additionally, Cloud Files provides a simple yet powerful way to publish and distribute content
  * behind a Content Distribution Network.
- * 
+ *
  * @see CDNApi
  * @see SwiftApi
  */
@@ -41,21 +41,21 @@ public interface CloudFilesApi extends SwiftApi {
 
    /**
     * Provides access to Cloud Files CDN features.
-    * 
+    *
     * @param region  the region to access the CDN API.
-    * 
+    *
     * @return the {@link CDNApi} for the specified region.
     */
    @Delegate
-   CDNApi getCDNApiForRegion(@EndpointParam(parser = RegionToCDNEndpoint.class) @Nullable String region);
+   CDNApi getCDNApi(@EndpointParam(parser = RegionToCDNEndpoint.class) @Nullable String region);
 
    /**
     * Provides access to Cloud Files CDN features.
-    * 
+    *
     * @param region  the region to access the CDN API.
-    * 
+    *
     * @return the {@link CDNApi} for the specified region.
-    * 
+    *
     * @deprecated Please use {@link #getCDNApiForRegion(String)}. This method will be removed in jclouds 1.8.
     */
    @Deprecated

--- a/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/features/CloudFilesAccountApiLiveTest.java
+++ b/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/features/CloudFilesAccountApiLiveTest.java
@@ -36,8 +36,8 @@ public class CloudFilesAccountApiLiveTest extends AccountApiLiveTest {
    }
 
    public void testUrlKeyExists() throws Exception {
-      for (String regionId : regions) {
-         Account account = api.getAccountApiForRegion(regionId).get();
+      for (String region : regions) {
+         Account account = api.getAccountApi(region).get();
          assertTrue(account.getTemporaryUrlKey().isPresent());
       }
    }

--- a/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/features/CloudFilesCDNApiLiveTest.java
+++ b/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/features/CloudFilesCDNApiLiveTest.java
@@ -53,20 +53,20 @@ public class CloudFilesCDNApiLiveTest extends BaseCloudFilesApiLiveTest {
    }
 
    public void testEnable() throws Exception {
-      for (String regionId : regions) {
-         assertNotNull(api.getCDNApiForRegion(regionId).enable(name));
-         
-         CDNContainer container = api.getCDNApiForRegion(regionId).get(name);
+      for (String region : regions) {
+         assertNotNull(api.getCDNApi(region).enable(name));
+
+         CDNContainer container = api.getCDNApi(region).get(name);
          assertCDNContainerNotNull(container);
          assertTrue(container.isEnabled());
       }
    }
 
    public void testEnableWithTTL() throws Exception {
-      for (String regionId : regions) {
-         assertNotNull(api.getCDNApiForRegion(regionId).enable(name, 777777));
+      for (String region : regions) {
+         assertNotNull(api.getCDNApi(region).enable(name, 777777));
 
-         CDNContainer container = api.getCDNApiForRegion(regionId).get(name);
+         CDNContainer container = api.getCDNApi(region).get(name);
          assertCDNContainerNotNull(container);
          assertTrue(container.isEnabled());
          assertTrue(container.getTtl() == 777777);
@@ -74,19 +74,19 @@ public class CloudFilesCDNApiLiveTest extends BaseCloudFilesApiLiveTest {
    }
 
    public void testDisable() throws Exception {
-      for (String regionId : regions) {
-         assertTrue(api.getCDNApiForRegion(regionId).disable(name));
+      for (String region : regions) {
+         assertTrue(api.getCDNApi(region).disable(name));
 
-         CDNContainer container = api.getCDNApiForRegion(regionId).get(name);
+         CDNContainer container = api.getCDNApi(region).get(name);
          assertFalse(container.isEnabled());
       }
    }
 
    public void testList() throws Exception {
-      for (String regionId : regions) {
-         List<CDNContainer> cdnResponse = api.getCDNApiForRegion(regionId).list().toList();
+      for (String region : regions) {
+         List<CDNContainer> cdnResponse = api.getCDNApi(region).list().toList();
          assertNotNull(cdnResponse);
-         
+
          for (CDNContainer cdnContainer : cdnResponse) {
             assertCDNContainerNotNull(cdnContainer);
             assertTrue(cdnContainer.isEnabled());
@@ -96,35 +96,35 @@ public class CloudFilesCDNApiLiveTest extends BaseCloudFilesApiLiveTest {
 
    public void testListWithOptions() throws Exception {
       String lexicographicallyBeforeName = name.substring(0, name.length() - 1);
-      for (String regionId : regions) {
+      for (String region : regions) {
          ListCDNContainerOptions options = new ListCDNContainerOptions().marker(lexicographicallyBeforeName);
-          
-         CDNContainer cdnContainer = api.getCDNApiForRegion(regionId).list(options).get(0);
+
+         CDNContainer cdnContainer = api.getCDNApi(region).list(options).get(0);
          assertCDNContainerNotNull(cdnContainer);
          assertTrue(cdnContainer.isEnabled());
       }
    }
 
    public void testGet() throws Exception {
-      for (String regionId : regions) {
-         CDNContainer container = api.getCDNApiForRegion(regionId).get(name);
+      for (String region : regions) {
+         CDNContainer container = api.getCDNApi(region).get(name);
          assertCDNContainerNotNull(container);
          assertTrue(container.isEnabled());
       }
    }
 
    public void testPurgeObject() throws Exception {
-      for (String regionId : regions) {
+      for (String region : regions) {
          String objectName = "testPurge";
          Payload payload = Payloads.newByteSourcePayload(ByteSource.wrap(new byte[] {1, 2, 3}));
-         ObjectApi objectApi = api.getObjectApiForRegionAndContainer(regionId, name);
-         
+         ObjectApi objectApi = api.getObjectApiForContainer(region, name);
+
          // create a new object
          objectApi.put(objectName, payload);
-         
-         CDNApi cdnApi = api.getCDNApiForRegion(regionId);
+
+         CDNApi cdnApi = api.getCDNApi(region);
          assertTrue(cdnApi.purgeObject(name, "testPurge", ImmutableList.<String>of()));
-         
+
          // delete the object
          objectApi.delete(objectName);
          assertNull(objectApi.get(objectName, GetOptions.NONE));
@@ -132,12 +132,12 @@ public class CloudFilesCDNApiLiveTest extends BaseCloudFilesApiLiveTest {
    }
 
    public void testUpdate() throws Exception {
-      for (String regionId : regions) {
+      for (String region : regions) {
          // enable with a ttl
-         assertNotNull(api.getCDNApiForRegion(regionId).enable(name, 777777));
-         
+         assertNotNull(api.getCDNApi(region).enable(name, 777777));
+
          // now get the container
-         CDNContainer original = api.getCDNApiForRegion(regionId).get(name);
+         CDNContainer original = api.getCDNApi(region).get(name);
          assertTrue(original.isEnabled());
          assertCDNContainerNotNull(original);
 
@@ -147,13 +147,13 @@ public class CloudFilesCDNApiLiveTest extends BaseCloudFilesApiLiveTest {
                                                 .logRetention(true)
                                                 .enabled(false);
          // update the container
-         assertTrue(api.getCDNApiForRegion(regionId).update(name, opts));
-         
+         assertTrue(api.getCDNApi(region).update(name, opts));
+
          // now get the updated container
-         CDNContainer updated = api.getCDNApiForRegion(regionId).get(name);
+         CDNContainer updated = api.getCDNApi(region).get(name);
          assertFalse(updated.isEnabled());
          assertCDNContainerNotNull(updated);
-         
+
          assertNotEquals(original.getTtl(), updated.getTtl());
          assertTrue(updated.isLogRetentionEnabled());
       }
@@ -173,17 +173,17 @@ public class CloudFilesCDNApiLiveTest extends BaseCloudFilesApiLiveTest {
    @BeforeClass(groups = "live")
    public void setup() {
       super.setup();
-      for (String regionId : regions) {
-         api.getContainerApiForRegion(regionId).create(name);
+      for (String region : regions) {
+         api.getContainerApi(region).create(name);
       }
    }
 
    @Override
    @AfterClass(groups = "live")
    public void tearDown() {
-      for (String regionId : regions) {
-         api.getCDNApiForRegion(regionId).disable(name);
-         api.getContainerApiForRegion(regionId).deleteIfEmpty(name);
+      for (String region : regions) {
+         api.getCDNApi(region).disable(name);
+         api.getContainerApi(region).deleteIfEmpty(name);
       }
       super.tearDown();
    }

--- a/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/features/CloudFilesCDNApiMockTest.java
+++ b/rackspace-cloudfiles/src/test/java/org/jclouds/rackspace/cloudfiles/v1/features/CloudFilesCDNApiMockTest.java
@@ -61,7 +61,7 @@ public class CloudFilesCDNApiMockTest extends BaseOpenStackMockTest<CloudFilesAp
 
       try {
          CloudFilesApi api = api(server.getUrl("/").toString(), "rackspace-cloudfiles");
-         CDNApi cdnApi = api.getCDNApiForRegion("DFW");
+         CDNApi cdnApi = api.getCDNApi("DFW");
 
          ImmutableList<CDNContainer> cdnContainers = cdnApi.list().toList();
 
@@ -82,7 +82,7 @@ public class CloudFilesCDNApiMockTest extends BaseOpenStackMockTest<CloudFilesAp
 
       try {
          CloudFilesApi api = api(server.getUrl("/").toString(), "rackspace-cloudfiles");
-         CDNApi cdnApi = api.getCDNApiForRegion("DFW");
+         CDNApi cdnApi = api.getCDNApi("DFW");
 
          List<CDNContainer> cdnContainers = cdnApi.list().toList();
 
@@ -104,7 +104,7 @@ public class CloudFilesCDNApiMockTest extends BaseOpenStackMockTest<CloudFilesAp
       try {
          CloudFilesApi api = api(server.getUrl("/").toString(), "rackspace-cloudfiles");
          ListCDNContainerOptions options = new ListCDNContainerOptions().marker("cdn-container-3");
-         ImmutableList<CDNContainer> containers = api.getCDNApiForRegion("DFW").list(options).toList();
+         ImmutableList<CDNContainer> containers = api.getCDNApi("DFW").list(options).toList();
 
          for (CDNContainer container : containers) {
             assertCDNContainerNotNull(container);
@@ -128,7 +128,7 @@ public class CloudFilesCDNApiMockTest extends BaseOpenStackMockTest<CloudFilesAp
       try {
          CloudFilesApi api = api(server.getUrl("/").toString(), "rackspace-cloudfiles");
          ListCDNContainerOptions options = ListCDNContainerOptions.Builder.marker("cdn-container-3");
-         FluentIterable<CDNContainer> containers = api.getCDNApiForRegion("DFW").list(options);
+         FluentIterable<CDNContainer> containers = api.getCDNApi("DFW").list(options);
 
          assertEquals(server.getRequestCount(), 2);
          assertAuthentication(server);
@@ -150,7 +150,7 @@ public class CloudFilesCDNApiMockTest extends BaseOpenStackMockTest<CloudFilesAp
          CloudFilesApi api = api(server.getUrl("/").toString(), "rackspace-cloudfiles");
 
          // enable a CDN Container
-         URI enabledContainer = api.getCDNApiForRegion("DFW").enable("container-1");
+         URI enabledContainer = api.getCDNApi("DFW").enable("container-1");
          assertNotNull(enabledContainer);
 
          assertEquals(server.getRequestCount(), 2);
@@ -165,11 +165,11 @@ public class CloudFilesCDNApiMockTest extends BaseOpenStackMockTest<CloudFilesAp
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
       server.enqueue(addCommonHeaders(enabledResponse().setResponseCode(404)));
- 
+
       try {
          CloudFilesApi api = api(server.getUrl("/").toString(), "rackspace-cloudfiles");
          // enable a CDN Container
-         assertNull(api.getCDNApiForRegion("DFW").enable("container-1"));
+         assertNull(api.getCDNApi("DFW").enable("container-1"));
 
          assertEquals(server.getRequestCount(), 2);
          assertAuthentication(server);
@@ -188,7 +188,7 @@ public class CloudFilesCDNApiMockTest extends BaseOpenStackMockTest<CloudFilesAp
          CloudFilesApi api = api(server.getUrl("/").toString(), "rackspace-cloudfiles");
 
          // enable a CDN Container with a TTL
-         URI enabledContainer = api.getCDNApiForRegion("DFW").enable("container-1", 777777);
+         URI enabledContainer = api.getCDNApi("DFW").enable("container-1", 777777);
          assertNotNull(enabledContainer);
 
          assertEquals(server.getRequestCount(), 2);
@@ -208,7 +208,7 @@ public class CloudFilesCDNApiMockTest extends BaseOpenStackMockTest<CloudFilesAp
          CloudFilesApi api = api(server.getUrl("/").toString(), "rackspace-cloudfiles");
 
          // enable a CDN Container with a TTL
-         URI enabledContainer = api.getCDNApiForRegion("DFW").enable("container-1", 777777);
+         URI enabledContainer = api.getCDNApi("DFW").enable("container-1", 777777);
          assertNull(enabledContainer);
 
          assertEquals(server.getRequestCount(), 2);
@@ -228,7 +228,7 @@ public class CloudFilesCDNApiMockTest extends BaseOpenStackMockTest<CloudFilesAp
          CloudFilesApi api = api(server.getUrl("/").toString(), "rackspace-cloudfiles");
 
          // disable a CDN Container
-         assertTrue(api.getCDNApiForRegion("DFW").disable("container-1"));
+         assertTrue(api.getCDNApi("DFW").disable("container-1"));
 
          assertEquals(server.getRequestCount(), 2);
          assertAuthentication(server);
@@ -247,7 +247,7 @@ public class CloudFilesCDNApiMockTest extends BaseOpenStackMockTest<CloudFilesAp
          CloudFilesApi api = api(server.getUrl("/").toString(), "rackspace-cloudfiles");
 
          // disable a CDN Container
-         boolean disbledContainer = api.getCDNApiForRegion("DFW").disable("container-1");
+         boolean disbledContainer = api.getCDNApi("DFW").disable("container-1");
          assertFalse(disbledContainer);
 
          assertEquals(server.getRequestCount(), 2);
@@ -262,11 +262,11 @@ public class CloudFilesCDNApiMockTest extends BaseOpenStackMockTest<CloudFilesAp
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
       server.enqueue(addCommonHeaders(enabledResponse().setResponseCode(201)));
-      
+
       try {
          CloudFilesApi api = api(server.getUrl("/").toString(), "rackspace-cloudfiles");
 
-         CDNContainer cdnContainer = api.getCDNApiForRegion("DFW").get("container-1");
+         CDNContainer cdnContainer = api.getCDNApi("DFW").get("container-1");
          assertCDNContainerNotNull(cdnContainer);
          assertEquals(mockCDNContainer, cdnContainer);
 
@@ -286,7 +286,7 @@ public class CloudFilesCDNApiMockTest extends BaseOpenStackMockTest<CloudFilesAp
       try {
          CloudFilesApi api = api(server.getUrl("/").toString(), "rackspace-cloudfiles");
 
-         CDNContainer cdnContainer = api.getCDNApiForRegion("DFW").get("cdn-container with spaces");
+         CDNContainer cdnContainer = api.getCDNApi("DFW").get("cdn-container with spaces");
          assertCDNContainerNotNull(cdnContainer);
          assertEquals(mockCDNContainerWithSpaces, cdnContainer);
 
@@ -306,7 +306,7 @@ public class CloudFilesCDNApiMockTest extends BaseOpenStackMockTest<CloudFilesAp
       try {
          CloudFilesApi api = api(server.getUrl("/").toString(), "rackspace-cloudfiles");
 
-         CDNContainer cdnContainer = api.getCDNApiForRegion("DFW").get("container-1");
+         CDNContainer cdnContainer = api.getCDNApi("DFW").get("container-1");
 
          assertAuthentication(server);
          assertRequest(server.takeRequest(), "HEAD", "/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9/container-1");
@@ -325,7 +325,7 @@ public class CloudFilesCDNApiMockTest extends BaseOpenStackMockTest<CloudFilesAp
          CloudFilesApi api = api(server.getUrl("/").toString(), "rackspace-cloudfiles");
 
          // purge the object
-         assertTrue(api.getCDNApiForRegion("DFW").purgeObject("myContainer", "myObject", emails));
+         assertTrue(api.getCDNApi("DFW").purgeObject("myContainer", "myObject", emails));
 
          assertEquals(server.getRequestCount(), 2);
          assertAuthentication(server);
@@ -344,7 +344,7 @@ public class CloudFilesCDNApiMockTest extends BaseOpenStackMockTest<CloudFilesAp
          CloudFilesApi api = api(server.getUrl("/").toString(), "rackspace-cloudfiles");
 
          // purge the object
-         assertFalse(api.getCDNApiForRegion("DFW").purgeObject("myContainer", "myObject", emails));
+         assertFalse(api.getCDNApi("DFW").purgeObject("myContainer", "myObject", emails));
 
          assertEquals(server.getRequestCount(), 2);
          assertAuthentication(server);
@@ -364,13 +364,13 @@ public class CloudFilesCDNApiMockTest extends BaseOpenStackMockTest<CloudFilesAp
       try {
          CloudFilesApi api = api(server.getUrl("/").toString(), "rackspace-cloudfiles");
 
-         CDNContainer cdnContainer = api.getCDNApiForRegion("DFW").get("container-1");
+         CDNContainer cdnContainer = api.getCDNApi("DFW").get("container-1");
          assertCDNContainerNotNull(cdnContainer);
 
          // update the CDN Container
-         assertTrue(api.getCDNApiForRegion("DFW").update("container-1", enabled(false).logRetention(true).ttl(7654321)));
+         assertTrue(api.getCDNApi("DFW").update("container-1", enabled(false).logRetention(true).ttl(7654321)));
 
-         cdnContainer = api.getCDNApiForRegion("DFW").get("container-1");
+         cdnContainer = api.getCDNApi("DFW").get("container-1");
          assertCDNContainerNotNull(cdnContainer);
 
          CDNContainer updatedContainer = CDNContainer.builder()
@@ -405,11 +405,11 @@ public class CloudFilesCDNApiMockTest extends BaseOpenStackMockTest<CloudFilesAp
       try {
          CloudFilesApi api = api(server.getUrl("/").toString(), "rackspace-cloudfiles");
 
-         CDNContainer cdnContainer = api.getCDNApiForRegion("DFW").get("container-1");
+         CDNContainer cdnContainer = api.getCDNApi("DFW").get("container-1");
          assertCDNContainerNotNull(cdnContainer);
 
          // update the CDN Container
-         assertFalse(api.getCDNApiForRegion("DFW").update("container-1", enabled(false).logRetention(true).ttl(7654321)));
+         assertFalse(api.getCDNApi("DFW").update("container-1", enabled(false).logRetention(true).ttl(7654321)));
 
          assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);

--- a/rackspace-cloudqueues-uk/src/main/java/org/jclouds/rackspace/cloudqueues/uk/CloudQueuesUKProviderMetadata.java
+++ b/rackspace-cloudqueues-uk/src/main/java/org/jclouds/rackspace/cloudqueues/uk/CloudQueuesUKProviderMetadata.java
@@ -16,9 +16,16 @@
  */
 package org.jclouds.rackspace.cloudqueues.uk;
 
-import com.google.common.collect.ImmutableSet;
-import com.google.inject.Module;
-import org.jclouds.openstack.keystone.v2_0.config.KeystoneAuthenticationModule.ZoneModule;
+import static org.jclouds.location.reference.LocationConstants.ISO3166_CODES;
+import static org.jclouds.location.reference.LocationConstants.PROPERTY_REGION;
+import static org.jclouds.location.reference.LocationConstants.PROPERTY_REGIONS;
+import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.CREDENTIAL_TYPE;
+import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.SERVICE_TYPE;
+
+import java.net.URI;
+import java.util.Properties;
+
+import org.jclouds.openstack.keystone.v2_0.config.KeystoneAuthenticationModule.RegionModule;
 import org.jclouds.openstack.marconi.v1.MarconiApiMetadata;
 import org.jclouds.openstack.marconi.v1.config.MarconiHttpApiModule;
 import org.jclouds.openstack.marconi.v1.config.MarconiTypeAdapters;
@@ -29,14 +36,8 @@ import org.jclouds.rackspace.cloudidentity.v2_0.config.CloudIdentityAuthenticati
 import org.jclouds.rackspace.cloudidentity.v2_0.config.CloudIdentityAuthenticationModule;
 import org.jclouds.rackspace.cloudidentity.v2_0.config.CloudIdentityCredentialTypes;
 
-import java.net.URI;
-import java.util.Properties;
-
-import static org.jclouds.location.reference.LocationConstants.ISO3166_CODES;
-import static org.jclouds.location.reference.LocationConstants.PROPERTY_ZONE;
-import static org.jclouds.location.reference.LocationConstants.PROPERTY_ZONES;
-import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.CREDENTIAL_TYPE;
-import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.SERVICE_TYPE;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Module;
 
 /**
  * Implementation of Rackspace Cloud Queues.
@@ -64,12 +65,12 @@ public class CloudQueuesUKProviderMetadata extends BaseProviderMetadata {
       Properties properties = new Properties();
       properties.setProperty(CREDENTIAL_TYPE, CloudIdentityCredentialTypes.API_KEY_CREDENTIALS);
       properties.setProperty(SERVICE_TYPE, ServiceType.QUEUES);
-      properties.setProperty(PROPERTY_ZONES, "LON");
-      properties.setProperty(PROPERTY_ZONE + ".LON." + ISO3166_CODES, "GB-SLG");
+      properties.setProperty(PROPERTY_REGIONS, "LON");
+      properties.setProperty(PROPERTY_REGION + ".LON." + ISO3166_CODES, "GB-SLG");
 
       return properties;
    }
-   
+
    public static class Builder extends BaseProviderMetadata.Builder {
 
       protected Builder(){
@@ -84,7 +85,7 @@ public class CloudQueuesUKProviderMetadata extends BaseProviderMetadata {
                .defaultModules(ImmutableSet.<Class<? extends Module>>builder()
                      .add(CloudIdentityAuthenticationApiModule.class)
                      .add(CloudIdentityAuthenticationModule.class)
-                     .add(ZoneModule.class)
+                     .add(RegionModule.class)
                      .add(MarconiTypeAdapters.class)
                      .add(MarconiHttpApiModule.class).build())
                .build())

--- a/rackspace-cloudqueues-us/src/main/java/org/jclouds/rackspace/cloudqueues/us/CloudQueuesUSProviderMetadata.java
+++ b/rackspace-cloudqueues-us/src/main/java/org/jclouds/rackspace/cloudqueues/us/CloudQueuesUSProviderMetadata.java
@@ -16,9 +16,16 @@
  */
 package org.jclouds.rackspace.cloudqueues.us;
 
-import com.google.common.collect.ImmutableSet;
-import com.google.inject.Module;
-import org.jclouds.openstack.keystone.v2_0.config.KeystoneAuthenticationModule.ZoneModule;
+import static org.jclouds.location.reference.LocationConstants.ISO3166_CODES;
+import static org.jclouds.location.reference.LocationConstants.PROPERTY_REGION;
+import static org.jclouds.location.reference.LocationConstants.PROPERTY_REGIONS;
+import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.CREDENTIAL_TYPE;
+import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.SERVICE_TYPE;
+
+import java.net.URI;
+import java.util.Properties;
+
+import org.jclouds.openstack.keystone.v2_0.config.KeystoneAuthenticationModule.RegionModule;
 import org.jclouds.openstack.marconi.v1.MarconiApiMetadata;
 import org.jclouds.openstack.marconi.v1.config.MarconiHttpApiModule;
 import org.jclouds.openstack.marconi.v1.config.MarconiTypeAdapters;
@@ -29,14 +36,8 @@ import org.jclouds.rackspace.cloudidentity.v2_0.config.CloudIdentityAuthenticati
 import org.jclouds.rackspace.cloudidentity.v2_0.config.CloudIdentityAuthenticationModule;
 import org.jclouds.rackspace.cloudidentity.v2_0.config.CloudIdentityCredentialTypes;
 
-import java.net.URI;
-import java.util.Properties;
-
-import static org.jclouds.location.reference.LocationConstants.ISO3166_CODES;
-import static org.jclouds.location.reference.LocationConstants.PROPERTY_ZONE;
-import static org.jclouds.location.reference.LocationConstants.PROPERTY_ZONES;
-import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.CREDENTIAL_TYPE;
-import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.SERVICE_TYPE;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Module;
 
 /**
  * Implementation of Rackspace Cloud Queues.
@@ -65,16 +66,16 @@ public class CloudQueuesUSProviderMetadata extends BaseProviderMetadata {
       properties.setProperty(CREDENTIAL_TYPE, CloudIdentityCredentialTypes.API_KEY_CREDENTIALS);
       properties.setProperty(SERVICE_TYPE, ServiceType.QUEUES);
 
-      properties.setProperty(PROPERTY_ZONES, "ORD,DFW,IAD,SYD,HKG");
-      properties.setProperty(PROPERTY_ZONE + ".ORD." + ISO3166_CODES, "US-IL");
-      properties.setProperty(PROPERTY_ZONE + ".DFW." + ISO3166_CODES, "US-TX");
-      properties.setProperty(PROPERTY_ZONE + ".IAD." + ISO3166_CODES, "US-VA");
-      properties.setProperty(PROPERTY_ZONE + ".SYD." + ISO3166_CODES, "AU-NSW");
-      properties.setProperty(PROPERTY_ZONE + ".HKG." + ISO3166_CODES, "HK");
+      properties.setProperty(PROPERTY_REGIONS, "ORD,DFW,IAD,SYD,HKG");
+      properties.setProperty(PROPERTY_REGION + ".ORD." + ISO3166_CODES, "US-IL");
+      properties.setProperty(PROPERTY_REGION + ".DFW." + ISO3166_CODES, "US-TX");
+      properties.setProperty(PROPERTY_REGION + ".IAD." + ISO3166_CODES, "US-VA");
+      properties.setProperty(PROPERTY_REGION + ".SYD." + ISO3166_CODES, "AU-NSW");
+      properties.setProperty(PROPERTY_REGION + ".HKG." + ISO3166_CODES, "HK");
 
       return properties;
    }
-   
+
    public static class Builder extends BaseProviderMetadata.Builder {
 
       protected Builder(){
@@ -89,7 +90,7 @@ public class CloudQueuesUSProviderMetadata extends BaseProviderMetadata {
                   .defaultModules(ImmutableSet.<Class<? extends Module>>builder()
                                               .add(CloudIdentityAuthenticationApiModule.class)
                                               .add(CloudIdentityAuthenticationModule.class)
-                                              .add(ZoneModule.class)
+                                              .add(RegionModule.class)
                                               .add(MarconiTypeAdapters.class)
                                               .add(MarconiHttpApiModule.class).build())
                   .build())


### PR DESCRIPTION
This PR removes all references to "zone" in the OpenStack APIs in favor of the common "region" nomenclature as described in [JCLOUDS-647](https://issues.apache.org/jira/browse/JCLOUDS-647).

The related [PR 463](https://github.com/jclouds/jclouds/pull/463) in the jclouds/jclouds project will need to be merged first!
