### PR TITLE
JCLOUDS-568 Allow updating content-type in metadata

### DIFF
--- a/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/binders/BindMetadataToHeaders.java
+++ b/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/binders/BindMetadataToHeaders.java
@@ -16,38 +16,36 @@
  */
 package org.jclouds.openstack.swift.v1.binders;
 
-import static org.jclouds.openstack.swift.v1.reference.SwiftHeaders.ACCOUNT_METADATA_PREFIX;
-import static org.jclouds.openstack.swift.v1.reference.SwiftHeaders.CONTAINER_METADATA_PREFIX;
-import static org.jclouds.openstack.swift.v1.reference.SwiftHeaders.OBJECT_METADATA_PREFIX;
-
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableMultimap.Builder;
+import org.jclouds.http.HttpRequest;
+import org.jclouds.rest.Binder;
 
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.jclouds.http.HttpRequest;
-import org.jclouds.rest.Binder;
-
-import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.ImmutableMultimap.Builder;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.jclouds.openstack.swift.v1.reference.SwiftHeaders.ACCOUNT_METADATA_PREFIX;
+import static org.jclouds.openstack.swift.v1.reference.SwiftHeaders.CONTAINER_METADATA_PREFIX;
+import static org.jclouds.openstack.swift.v1.reference.SwiftHeaders.OBJECT_METADATA_PREFIX;
 
 /**
  * Will lower-case header keys due to a swift implementation to return headers
  * in a different case than sent. ex.
- * 
+ *
  * <pre>
  * >> X-Account-Meta-MyDelete1: foo
  * >> X-Account-Meta-MyDelete2: bar
  * </pre>
- * 
+ *
  * results in:
- * 
+ *
  * <pre>
  * << X-Account-Meta-Mydelete1: foo
  * << X-Account-Meta-Mydelete2: bar
  * </pre>
- * 
+ *
  * <h4>Note</h4> <br/>
  * HTTP response headers keys are known to be case-insensitive, but this
  * practice of mixing up case will prevent metadata keys such as those in
@@ -132,6 +130,8 @@ public class BindMetadataToHeaders implements Binder {
          String keyInLowercase = keyVal.getKey().toLowerCase();
          if (keyVal.getKey().startsWith(metadataPrefix)) {
             putMetadata(builder, keyInLowercase, keyVal.getValue());
+         } else if (keyInLowercase.equals("content-type")) {
+            putMetadata(builder, "Content-Type", keyVal.getValue());
          } else {
             putMetadata(builder, String.format("%s%s", metadataPrefix, keyInLowercase), keyVal.getValue());
          }

--- a/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/features/ObjectApi.java
+++ b/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/features/ObjectApi.java
@@ -16,23 +16,7 @@
  */
 package org.jclouds.openstack.swift.v1.features;
 
-import static com.google.common.net.HttpHeaders.EXPECT;
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static org.jclouds.openstack.swift.v1.reference.SwiftHeaders.OBJECT_COPY_FROM;
-
-import java.util.Map;
-
-import javax.inject.Named;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.HEAD;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-
+import com.google.common.annotations.Beta;
 import org.jclouds.Fallbacks.FalseOnNotFoundOr404;
 import org.jclouds.Fallbacks.NullOnNotFoundOr404;
 import org.jclouds.Fallbacks.VoidOnNotFoundOr404;
@@ -46,6 +30,7 @@ import org.jclouds.openstack.swift.v1.binders.BindMetadataToHeaders.BindRemoveOb
 import org.jclouds.openstack.swift.v1.binders.SetPayload;
 import org.jclouds.openstack.swift.v1.domain.ObjectList;
 import org.jclouds.openstack.swift.v1.domain.SwiftObject;
+import org.jclouds.openstack.swift.v1.filters.ContentTypeFilter;
 import org.jclouds.openstack.swift.v1.functions.ETagHeader;
 import org.jclouds.openstack.swift.v1.functions.ParseObjectFromResponse;
 import org.jclouds.openstack.swift.v1.functions.ParseObjectListFromResponse;
@@ -58,7 +43,21 @@ import org.jclouds.rest.annotations.QueryParams;
 import org.jclouds.rest.annotations.RequestFilters;
 import org.jclouds.rest.annotations.ResponseParser;
 
-import com.google.common.annotations.Beta;
+import javax.inject.Named;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.HEAD;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import java.util.Map;
+
+import static com.google.common.net.HttpHeaders.EXPECT;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.jclouds.openstack.swift.v1.reference.SwiftHeaders.OBJECT_COPY_FROM;
 
 /**
  * Provides access to the OpenStack Object Storage (Swift) Object API features.
@@ -74,7 +73,7 @@ public interface ObjectApi {
 
    /**
     * Lists up to 10,000 objects.
-    * 
+    *
     * @return an {@link ObjectList} of {@link SwiftObject} ordered by name or {@code null}.
     */
    @Named("object:list")
@@ -90,10 +89,10 @@ public interface ObjectApi {
     * Lists up to 10,000 objects. To control a large list of containers beyond
     * 10,000 objects, use the {@code marker} and {@code endMarker} parameters in the
     * {@link ListContainerOptions} class.
-    * 
-    * @param options  
+    *
+    * @param options
     *           the {@link ListContainerOptions} for controlling the returned list.
-    * 
+    *
     * @return an {@link ObjectList} of {@link SwiftObject} ordered by name or {@code null}.
     */
    @Named("object:list")
@@ -107,7 +106,7 @@ public interface ObjectApi {
 
    /**
     * Creates or updates a {@link SwiftObject}.
-    * 
+    *
     * @param objectName
     *           corresponds to {@link SwiftObject#getName()}.
     * @param payload
@@ -124,14 +123,14 @@ public interface ObjectApi {
 
    /**
     * Creates or updates a {@link SwiftObject}.
-    * 
+    *
     * @param objectName
     *           corresponds to {@link SwiftObject#getName()}.
     * @param payload
     *           corresponds to {@link SwiftObject#getPayload()}.
     * @param options
     *           {@link PutOptions options} to control creating the {@link SwiftObject}.
-    * 
+    *
     * @return {@link SwiftObject#getETag()} of the object.
     */
    @Named("object:put")
@@ -144,10 +143,10 @@ public interface ObjectApi {
 
    /**
     * Gets the {@link SwiftObject} metadata without its {@link Payload#openStream() body}.
-    * 
+    *
     * @param objectName
     *           corresponds to {@link SwiftObject#getName()}.
-    * 
+    *
     * @return the {@link SwiftObject} or {@code null}, if not found.
     */
    @Named("object:getWithoutBody")
@@ -160,10 +159,10 @@ public interface ObjectApi {
 
    /**
     * Gets the {@link SwiftObject} including its {@link Payload#openStream() body}.
-    * 
+    *
     * @param objectName
     *           corresponds to {@link SwiftObject#getName()}.
-    * 
+    *
     * @return the {@link SwiftObject} or {@code null}, if not found.
     */
    @Named("object:get")
@@ -176,12 +175,12 @@ public interface ObjectApi {
 
    /**
     * Gets the {@link SwiftObject} including its {@link Payload#openStream() body}.
-    * 
+    *
     * @param objectName
     *           corresponds to {@link SwiftObject#getName()}.
     * @param options
     *           options to control the download.
-    * 
+    *
     * @return the {@link SwiftObject} or {@code null}, if not found.
     */
    @Named("object:get")
@@ -194,32 +193,33 @@ public interface ObjectApi {
 
    /**
     * Creates or updates the metadata for a {@link SwiftObject}.
-    * 
+    *
     * @param objectName
     *           corresponds to {@link SwiftObject#getName()}.
     * @param metadata
     *           the metadata to create or update.
-    * 
-    * @return {@code true} if the metadata was successfully created or updated, 
+    *
+    * @return {@code true} if the metadata was successfully created or updated,
     *         {@code false} if not.
     */
    @Named("object:updateMetadata")
    @POST
    @Fallback(FalseOnNotFoundOr404.class)
    @Path("/{objectName}")
-   @Produces("")
+   //@Produces("")
+   @RequestFilters(ContentTypeFilter.class)
    boolean updateMetadata(@PathParam("objectName") String objectName,
          @BinderParam(BindObjectMetadataToHeaders.class) Map<String, String> metadata);
 
    /**
     * Deletes the metadata from a {@link SwiftObject}.
-    * 
+    *
     * @param objectName
     *           corresponds to {@link SwiftObject#getName()}.
     * @param metadata
     *           corresponds to {@link SwiftObject#getMetadata()}.
-    * 
-    * @return {@code true} if the metadata was successfully deleted, 
+    *
+    * @return {@code true} if the metadata was successfully deleted,
     *         {@code false} if not.
     */
    @Named("object:deleteMetadata")
@@ -231,7 +231,7 @@ public interface ObjectApi {
 
    /**
     * Deletes an object, if present.
-    * 
+    *
     * @param objectName
     *           corresponds to {@link SwiftObject#getName()}.
     */
@@ -242,20 +242,20 @@ public interface ObjectApi {
    void delete(@PathParam("objectName") String objectName);
 
    /**
-    * Copies an object from one container to another. 
-    * 
+    * Copies an object from one container to another.
+    *
     * <h3>NOTE</h3>
     * This is a server side copy.
-    * 
+    *
     * @param destinationObject
     *           the destination object name.
     * @param sourceContainer
     *           the source container name.
     * @param sourceObject
     *           the source object name.
-    * 
+    *
     * @return {@code true} if the object was successfully copied, {@code false} if not.
-    * 
+    *
     * @throws org.jclouds.openstack.swift.v1.CopyObjectException if the source or destination container do not exist.
     */
    @Named("object:copy")
@@ -288,14 +288,14 @@ public interface ObjectApi {
 
    /**
     * Creates or updates a {@link SwiftObject}.
-    * 
+    *
     * @param objectName
     *           corresponds to {@link SwiftObject#getName()}.
     * @param payload
     *           corresponds to {@link SwiftObject#getPayload()}.
     * @param metadata
     *           corresponds to {@link SwiftObject#getMetadata()}.
-    * 
+    *
     * @return {@link SwiftObject#getEtag()} of the object.
     *
     * @deprecated Please use {@link #put(String, Payload)} or {@link #put(String, Payload, PutOptions)}

--- a/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/filters/ContentTypeFilter.java
+++ b/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/filters/ContentTypeFilter.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.openstack.swift.v1.filters;
+
+import org.jclouds.http.HttpException;
+import org.jclouds.http.HttpRequest;
+import org.jclouds.http.HttpRequestFilter;
+
+import javax.inject.Singleton;
+
+/**
+ * Signs the Keystone-based request. This will update the Authentication Token before 24 hours is up.
+ */
+@Singleton
+public class ContentTypeFilter implements HttpRequestFilter {
+
+   @Override
+   public HttpRequest filter(HttpRequest request) throws HttpException {
+      if(!request.getHeaders().containsKey("Content-Type")) {
+         return request.toBuilder().addHeader("Content-Type", "").build();
+      } else {
+         return request;
+      }
+   }
+
+}


### PR DESCRIPTION
This ensures content-type will not be escaped in swift metadata.
This will allow changing the content type without reuploading the payload.
