### PR TITLE
Adds extension namespace support to Neutron

### DIFF
--- a/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2/config/NeutronHttpApiModule.java
+++ b/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2/config/NeutronHttpApiModule.java
@@ -16,12 +16,13 @@
  */
 package org.jclouds.openstack.neutron.v2.config;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
-import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.Multimap;
-import com.google.inject.Provides;
+import java.net.URI;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
 import org.jclouds.http.HttpErrorHandler;
 import org.jclouds.http.annotation.ClientError;
 import org.jclouds.http.annotation.Redirection;
@@ -29,6 +30,7 @@ import org.jclouds.http.annotation.ServerError;
 import org.jclouds.json.config.GsonModule.DateAdapter;
 import org.jclouds.json.config.GsonModule.Iso8601DateAdapter;
 import org.jclouds.openstack.neutron.v2.NeutronApi;
+import org.jclouds.openstack.neutron.v2.extensions.ExtensionNamespaces;
 import org.jclouds.openstack.neutron.v2.handlers.NeutronErrorHandler;
 import org.jclouds.openstack.v2_0.domain.Extension;
 import org.jclouds.openstack.v2_0.functions.PresentWhenExtensionAnnotationNamespaceEqualsAnyNamespaceInExtensionsSet;
@@ -36,11 +38,12 @@ import org.jclouds.rest.ConfiguresHttpApi;
 import org.jclouds.rest.config.HttpApiModule;
 import org.jclouds.rest.functions.ImplicitOptionalConverter;
 
-import javax.inject.Provider;
-import javax.inject.Singleton;
-import java.net.URI;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
+import com.google.inject.Provides;
 
 /**
  * Configures the Neutron connection.
@@ -60,6 +63,10 @@ public class NeutronHttpApiModule extends HttpApiModule<NeutronApi> {
    @Singleton
    public Multimap<URI, URI> aliases() {
        return ImmutableMultimap.<URI, URI>builder()
+          .put(URI.create(ExtensionNamespaces.L3_ROUTER),
+               URI.create("http://docs.openstack.org/ext/neutron/router/api/v1.0"))
+          .put(URI.create(ExtensionNamespaces.SECURITY_GROUPS),
+               URI.create("http://docs.openstack.org/ext/securitygroups/api/v2.0"))
           .build();
    }
 

--- a/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2/extensions/ExtensionNamespaces.java
+++ b/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2/extensions/ExtensionNamespaces.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.openstack.neutron.v2.extensions;
+
+/**
+ * Extension Namespaces for OpenStack Networking (Neutron).
+ */
+public final class ExtensionNamespaces {
+   /**
+    * Neutron Layer-3 Router Extension
+    */
+   public static final String L3_ROUTER = "http://docs.openstack.org/ext/neutron/router/api/v1.0";
+   /**
+    * Neutron Security Groups Extension
+    */
+   public static final String SECURITY_GROUPS = "http://docs.openstack.org/ext/securitygroups/api/v2.0";
+
+   private ExtensionNamespaces() {
+      throw new AssertionError("intentionally unimplemented");
+   }
+}

--- a/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2/extensions/FloatingIPApi.java
+++ b/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2/extensions/FloatingIPApi.java
@@ -37,7 +37,9 @@ import org.jclouds.openstack.neutron.v2.domain.FloatingIPs;
 import org.jclouds.openstack.neutron.v2.fallbacks.EmptyFloatingIPsFallback;
 import org.jclouds.openstack.neutron.v2.functions.FloatingIPsToPagedIterable;
 import org.jclouds.openstack.neutron.v2.functions.ParseFloatingIPs;
+import org.jclouds.openstack.v2_0.ServiceType;
 import org.jclouds.openstack.v2_0.options.PaginationOptions;
+import org.jclouds.openstack.v2_0.services.Extension;
 import org.jclouds.rest.annotations.Fallback;
 import org.jclouds.rest.annotations.RequestFilters;
 import org.jclouds.rest.annotations.ResponseParser;
@@ -59,6 +61,7 @@ import com.google.common.annotations.Beta;
 @Path("/floatingips")
 @RequestFilters(AuthenticateRequest.class)
 @Consumes(MediaType.APPLICATION_JSON)
+@Extension(of = ServiceType.NETWORK, namespace = ExtensionNamespaces.L3_ROUTER)
 public interface FloatingIPApi {
 
    /**

--- a/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2/extensions/RouterApi.java
+++ b/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2/extensions/RouterApi.java
@@ -39,7 +39,9 @@ import org.jclouds.openstack.neutron.v2.fallbacks.EmptyRoutersFallback;
 import org.jclouds.openstack.neutron.v2.functions.ParseRouters;
 import org.jclouds.openstack.neutron.v2.functions.RouterToPagedIterable;
 import org.jclouds.openstack.neutron.v2.options.EmptyOptions;
+import org.jclouds.openstack.v2_0.ServiceType;
 import org.jclouds.openstack.v2_0.options.PaginationOptions;
+import org.jclouds.openstack.v2_0.services.Extension;
 import org.jclouds.rest.annotations.Fallback;
 import org.jclouds.rest.annotations.MapBinder;
 import org.jclouds.rest.annotations.PayloadParam;
@@ -64,6 +66,7 @@ import com.google.common.annotations.Beta;
 @Path("/routers")
 @RequestFilters(AuthenticateRequest.class)
 @Consumes(MediaType.APPLICATION_JSON)
+@Extension(of = ServiceType.NETWORK, namespace = ExtensionNamespaces.L3_ROUTER)
 public interface RouterApi {
 
    /**

--- a/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2/extensions/SecurityGroupApi.java
+++ b/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2/extensions/SecurityGroupApi.java
@@ -41,13 +41,16 @@ import org.jclouds.openstack.neutron.v2.functions.ParseRules;
 import org.jclouds.openstack.neutron.v2.functions.ParseSecurityGroups;
 import org.jclouds.openstack.neutron.v2.functions.RulesToPagedIterable;
 import org.jclouds.openstack.neutron.v2.functions.SecurityGroupsToPagedIterable;
+import org.jclouds.openstack.v2_0.ServiceType;
 import org.jclouds.openstack.v2_0.options.PaginationOptions;
+import org.jclouds.openstack.v2_0.services.Extension;
 import org.jclouds.rest.annotations.Fallback;
 import org.jclouds.rest.annotations.RequestFilters;
 import org.jclouds.rest.annotations.ResponseParser;
 import org.jclouds.rest.annotations.SelectJson;
 import org.jclouds.rest.annotations.Transform;
 import org.jclouds.rest.annotations.WrapWith;
+
 import com.google.common.annotations.Beta;
 
 /**
@@ -61,6 +64,7 @@ import com.google.common.annotations.Beta;
 @RequestFilters(AuthenticateRequest.class)
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
+@Extension(of = ServiceType.NETWORK, namespace = ExtensionNamespaces.SECURITY_GROUPS)
 public interface SecurityGroupApi {
    /**
     * Groups

--- a/openstack-neutron/src/test/java/org/jclouds/openstack/neutron/v2/extensions/FloatingIPApiMockTest.java
+++ b/openstack-neutron/src/test/java/org/jclouds/openstack/neutron/v2/extensions/FloatingIPApiMockTest.java
@@ -47,6 +47,7 @@ public class FloatingIPApiMockTest extends BaseNeutronApiMockTest {
    public void testCreateFloatingIP() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(
             new MockResponse().setResponseCode(201).setBody(stringFromResource("/floatingip_create_response.json"))));
 
@@ -63,7 +64,9 @@ public class FloatingIPApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "POST", "/v2.0/floatingips", "/floatingip_create_request.json");
 
          /*
@@ -87,6 +90,7 @@ public class FloatingIPApiMockTest extends BaseNeutronApiMockTest {
    public void testCreateFloatingIPFail() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(
             new MockResponse().setResponseCode(404)));
 
@@ -107,6 +111,7 @@ public class FloatingIPApiMockTest extends BaseNeutronApiMockTest {
    public void testListSpecificPageFloatingIP() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(200).setBody(stringFromResource("/floatingip_list_response_paged1.json"))));
 
       try {
@@ -118,7 +123,9 @@ public class FloatingIPApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "GET", "/v2.0/floatingips?limit=2&marker=abcdefg");
 
          /*
@@ -136,6 +143,7 @@ public class FloatingIPApiMockTest extends BaseNeutronApiMockTest {
    public void testListSpecificPageFloatingIPFail() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404)));
 
       try {
@@ -147,7 +155,9 @@ public class FloatingIPApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "GET", "/v2.0/floatingips?limit=2&marker=abcdefg");
 
          /*
@@ -163,6 +173,7 @@ public class FloatingIPApiMockTest extends BaseNeutronApiMockTest {
    public void testListPagedFloatingIP() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(200).setBody(stringFromResource("/floatingip_list_response_paged1.json"))));
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(200).setBody(stringFromResource("/floatingip_list_response_paged2.json"))));
 
@@ -176,8 +187,9 @@ public class FloatingIPApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
-         assertEquals(server.getRequestCount(), 3);
+         assertEquals(server.getRequestCount(), 4);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "GET", "/v2.0/floatingips");
          assertRequest(server.takeRequest(), "GET", "/v2.0/floatingips?marker=71c1e68c-171a-4aa2-aca5-50ea153a3718");
 
@@ -196,6 +208,7 @@ public class FloatingIPApiMockTest extends BaseNeutronApiMockTest {
    public void testListPagedFloatingIPFail() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404)));
 
       try {
@@ -208,8 +221,9 @@ public class FloatingIPApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
-         assertEquals(server.getRequestCount(), 2);
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "GET", "/v2.0/floatingips");
 
          /*
@@ -225,6 +239,7 @@ public class FloatingIPApiMockTest extends BaseNeutronApiMockTest {
    public void testGetFloatingIP() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(
             new MockResponse().setResponseCode(201).setBody(stringFromResource("/floatingip_get_response.json"))));
 
@@ -237,7 +252,9 @@ public class FloatingIPApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "GET", "/v2.0/floatingips/12345");
 
          /*
@@ -260,6 +277,7 @@ public class FloatingIPApiMockTest extends BaseNeutronApiMockTest {
    public void testGetFloatingIPFail() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(
             new MockResponse().setResponseCode(404)));
 
@@ -272,7 +290,9 @@ public class FloatingIPApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "GET", "/v2.0/floatingips/12345");
 
          /*
@@ -288,6 +308,7 @@ public class FloatingIPApiMockTest extends BaseNeutronApiMockTest {
    public void testUpdateFloatingIP() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(
             new MockResponse().setResponseCode(201).setBody(stringFromResource("/floatingip_update_response.json"))));
 
@@ -304,7 +325,9 @@ public class FloatingIPApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "PUT", "/v2.0/floatingips/12345", "/floatingip_update_request.json");
 
          /*
@@ -321,6 +344,7 @@ public class FloatingIPApiMockTest extends BaseNeutronApiMockTest {
    public void testUpdateFloatingIPDissociate() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(
             new MockResponse().setResponseCode(201).setBody(stringFromResource("/floatingip_update_dissociate_response.json"))));
 
@@ -335,7 +359,9 @@ public class FloatingIPApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "PUT", "/v2.0/floatingips/12345", "/floatingip_update_dissociate_request.json");
 
          /*
@@ -352,6 +378,7 @@ public class FloatingIPApiMockTest extends BaseNeutronApiMockTest {
    public void testUpdateFloatingIPFail() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(
             new MockResponse().setResponseCode(404)));
 
@@ -368,7 +395,9 @@ public class FloatingIPApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "PUT", "/v2.0/floatingips/12345", "/floatingip_update_request.json");
 
          /*
@@ -383,6 +412,7 @@ public class FloatingIPApiMockTest extends BaseNeutronApiMockTest {
    public void testDeleteFloatingIP() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(
             new MockResponse().setResponseCode(201)));
 
@@ -395,7 +425,9 @@ public class FloatingIPApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "DELETE", "/v2.0/floatingips/12345");
 
          /*
@@ -410,6 +442,7 @@ public class FloatingIPApiMockTest extends BaseNeutronApiMockTest {
    public void testDeleteFloatingIPFail() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(
             new MockResponse().setResponseCode(404)));
 
@@ -422,7 +455,9 @@ public class FloatingIPApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "DELETE", "/v2.0/floatingips/12345");
 
          /*

--- a/openstack-neutron/src/test/java/org/jclouds/openstack/neutron/v2/extensions/RouterApiMockTest.java
+++ b/openstack-neutron/src/test/java/org/jclouds/openstack/neutron/v2/extensions/RouterApiMockTest.java
@@ -51,6 +51,7 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
    public void testCreateRouter() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(
             new MockResponse().setResponseCode(201).setBody(stringFromResource("/router_create_response.json"))));
 
@@ -67,7 +68,9 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "POST", "/v2.0/routers", "/router_create_request.json");
 
          /*
@@ -89,6 +92,7 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
    public void testCreateRouterFail() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(
             new MockResponse().setResponseCode(404)));
 
@@ -111,6 +115,7 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
    public void testListSpecificPageRouter() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(200).setBody(stringFromResource("/router_list_response_paged1.json"))));
 
       try {
@@ -122,7 +127,9 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "GET", "/v2.0/routers?limit=2&marker=abcdefg");
 
          /*
@@ -139,6 +146,7 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
    public void testListSpecificPageRouterFail() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404)));
 
       try {
@@ -150,7 +158,9 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "GET", "/v2.0/routers?limit=2&marker=abcdefg");
 
          /*
@@ -166,6 +176,7 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
    public void testListPagedRouter() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(200).setBody(stringFromResource("/router_list_response_paged1.json"))));
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(200).setBody(stringFromResource("/router_list_response_paged2.json"))));
 
@@ -179,8 +190,9 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
-         assertEquals(server.getRequestCount(), 3);
+         assertEquals(server.getRequestCount(), 4);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "GET", "/v2.0/routers");
          assertRequest(server.takeRequest(), "GET", "/v2.0/routers?marker=71c1e68c-171a-4aa2-aca5-50ea153a3718");
 
@@ -199,6 +211,7 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
    public void testListPagedRouterFail() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404)));
 
       try {
@@ -211,8 +224,9 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
-         assertEquals(server.getRequestCount(), 2);
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "GET", "/v2.0/routers");
 
          /*
@@ -228,6 +242,7 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
    public void testGetRouter() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(
             new MockResponse().setResponseCode(201).setBody(stringFromResource("/router_get_response.json"))));
 
@@ -240,7 +255,9 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "GET", "/v2.0/routers/12345");
 
          /*
@@ -261,6 +278,7 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
    public void testGetRouterFail() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(
             new MockResponse().setResponseCode(404)));
 
@@ -273,7 +291,9 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "GET", "/v2.0/routers/12345");
 
          /*
@@ -288,6 +308,7 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
    public void testUpdateRouter() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(
             new MockResponse().setResponseCode(201).setBody(stringFromResource("/router_update_response.json"))));
 
@@ -305,7 +326,9 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "PUT", "/v2.0/routers/12345", "/router_update_request.json");
 
          /*
@@ -326,6 +349,7 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
    public void testUpdateRouterFail() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(
             new MockResponse().setResponseCode(404)));
 
@@ -343,7 +367,9 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "PUT", "/v2.0/routers/12345", "/router_update_request.json");
 
          /*
@@ -358,6 +384,7 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
    public void testDeleteRouter() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(
             new MockResponse().setResponseCode(201)));
 
@@ -370,7 +397,9 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "DELETE", "/v2.0/routers/12345");
 
          /*
@@ -385,6 +414,7 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
    public void testDeleteRouterFail() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(
             new MockResponse().setResponseCode(404)));
 
@@ -397,7 +427,9 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "DELETE", "/v2.0/routers/12345");
 
          /*
@@ -412,6 +444,7 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
    public void testAddRouterInterfaceForSubnet() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(
             new MockResponse().setResponseCode(201).setBody(stringFromResource("/router_add_interface_response.json"))));
 
@@ -425,6 +458,7 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
           * Check request
           */
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "PUT", "/v2.0/routers/12345/add_router_interface", "/router_add_interface_request.json");
 
          /*
@@ -441,6 +475,7 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
    public void testAddRouterInterfaceForSubnetFail() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(
             new MockResponse().setResponseCode(404)));
 
@@ -453,7 +488,9 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "PUT", "/v2.0/routers/12345/add_router_interface", "/router_add_interface_request.json");
 
          /*
@@ -468,6 +505,7 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
    public void testAddRouterInterfaceForPort() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(
             new MockResponse().setResponseCode(201).setBody(stringFromResource("/router_add_interface_response.json"))));
 
@@ -480,7 +518,9 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "PUT", "/v2.0/routers/12345/add_router_interface", "/router_add_interface_port_request.json");
 
          /*
@@ -497,6 +537,7 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
    public void testAddRouterInterfaceForPortFail() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(
             new MockResponse().setResponseCode(404)));
 
@@ -509,7 +550,9 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "PUT", "/v2.0/routers/12345/add_router_interface", "/router_add_interface_port_request.json");
 
          /*
@@ -524,6 +567,7 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
    public void testRemoveRouterInterfaceForSubnet() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(
             new MockResponse().setResponseCode(201)));
 
@@ -536,7 +580,9 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "PUT", "/v2.0/routers/12345/remove_router_interface", "/router_remove_interface_subnet_request.json");
 
          /*
@@ -551,6 +597,7 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
    public void testRemoveRouterInterfaceForSubnetFail() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(
             new MockResponse().setResponseCode(404)));
 
@@ -563,7 +610,9 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "PUT", "/v2.0/routers/12345/remove_router_interface", "/router_remove_interface_subnet_request.json");
 
          /*
@@ -578,6 +627,7 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
    public void testRemoveRouterInterfaceForPort() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(
             new MockResponse().setResponseCode(201)));
 
@@ -590,7 +640,9 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "PUT", "/v2.0/routers/12345/remove_router_interface", "/router_remove_interface_port_request.json");
 
          /*
@@ -605,6 +657,7 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
    public void testRemoveRouterInterfaceForPortFail() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(
             new MockResponse().setResponseCode(404)));
 
@@ -617,7 +670,9 @@ public class RouterApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "PUT", "/v2.0/routers/12345/remove_router_interface", "/router_remove_interface_port_request.json");
 
          /*

--- a/openstack-neutron/src/test/java/org/jclouds/openstack/neutron/v2/extensions/SecurityGroupApiMockTest.java
+++ b/openstack-neutron/src/test/java/org/jclouds/openstack/neutron/v2/extensions/SecurityGroupApiMockTest.java
@@ -52,6 +52,7 @@ public class SecurityGroupApiMockTest extends BaseNeutronApiMockTest {
    public void testCreateSecurityGroup() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(
             new MockResponse().setResponseCode(201).setBody(stringFromResource("/security_group_create_response.json"))));
 
@@ -68,7 +69,9 @@ public class SecurityGroupApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "POST", "/v2.0/security-groups", "/security_group_create_request.json");
 
          /*
@@ -94,6 +97,7 @@ public class SecurityGroupApiMockTest extends BaseNeutronApiMockTest {
    public void testCreateSecurityGroupFail() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(
             new MockResponse().setResponseCode(404)));
 
@@ -114,6 +118,7 @@ public class SecurityGroupApiMockTest extends BaseNeutronApiMockTest {
    public void testCreateSecurityGroupRule() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(
             new MockResponse().setResponseCode(201).setBody(stringFromResource("/security_group_rule_create_response.json"))));
 
@@ -135,7 +140,9 @@ public class SecurityGroupApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "POST", "/v2.0/security-group-rules", "/security_group_rule_create_request.json");
 
          /*
@@ -161,6 +168,7 @@ public class SecurityGroupApiMockTest extends BaseNeutronApiMockTest {
    public void testCreateSecurityGroupRuleFail() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(
             new MockResponse().setResponseCode(404)));
 
@@ -186,6 +194,7 @@ public class SecurityGroupApiMockTest extends BaseNeutronApiMockTest {
    public void testListSpecificPageSecurityGroup() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(200).setBody(stringFromResource("/security_group_list_response_paged1.json"))));
 
       try {
@@ -197,7 +206,9 @@ public class SecurityGroupApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "GET", "/v2.0/security-groups?limit=2&marker=abcdefg");
 
          /*
@@ -216,6 +227,7 @@ public class SecurityGroupApiMockTest extends BaseNeutronApiMockTest {
    public void testListSpecificPageSecurityGroupFail() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404)));
 
       try {
@@ -227,7 +239,9 @@ public class SecurityGroupApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "GET", "/v2.0/security-groups?limit=2&marker=abcdefg");
 
          /*
@@ -243,6 +257,7 @@ public class SecurityGroupApiMockTest extends BaseNeutronApiMockTest {
    public void testListSpecificPageSecurityGroupRule() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(200).setBody(stringFromResource("/security_group_rule_list_response_paged1.json"))));
 
       try {
@@ -254,7 +269,9 @@ public class SecurityGroupApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "GET", "/v2.0/security-group-rules?limit=2&marker=abcdefg");
 
          /*
@@ -273,6 +290,7 @@ public class SecurityGroupApiMockTest extends BaseNeutronApiMockTest {
    public void testListSpecificPageSecurityGroupRuleFail() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404)));
 
       try {
@@ -284,7 +302,9 @@ public class SecurityGroupApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "GET", "/v2.0/security-group-rules?limit=2&marker=abcdefg");
 
          /*
@@ -300,6 +320,7 @@ public class SecurityGroupApiMockTest extends BaseNeutronApiMockTest {
    public void testListPagedSecurityGroups() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(200).setBody(stringFromResource("/security_group_list_response_paged1.json"))));
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(200).setBody(stringFromResource("/security_group_list_response_paged2.json"))));
 
@@ -313,8 +334,9 @@ public class SecurityGroupApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
-         assertEquals(server.getRequestCount(), 3);
+         assertEquals(server.getRequestCount(), 4);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "GET", "/v2.0/security-groups");
          assertRequest(server.takeRequest(), "GET", "/v2.0/security-groups?marker=71c1e68c-171a-4aa2-aca5-50ea153a3718");
 
@@ -335,6 +357,7 @@ public class SecurityGroupApiMockTest extends BaseNeutronApiMockTest {
    public void testListPagedSecurityGroupsFail() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404)));
 
       try {
@@ -347,8 +370,9 @@ public class SecurityGroupApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
-         assertEquals(server.getRequestCount(), 2);
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "GET", "/v2.0/security-groups");
 
          /*
@@ -365,6 +389,7 @@ public class SecurityGroupApiMockTest extends BaseNeutronApiMockTest {
    public void testListPagedSecurityGroupRules() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(200).setBody(stringFromResource("/security_group_rule_list_response_paged1.json"))));
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(200).setBody(stringFromResource("/security_group_rule_list_response_paged2.json"))));
 
@@ -378,8 +403,9 @@ public class SecurityGroupApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
-         assertEquals(server.getRequestCount(), 3);
+         assertEquals(server.getRequestCount(), 4);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "GET", "/v2.0/security-group-rules");
          assertRequest(server.takeRequest(), "GET", "/v2.0/security-group-rules?marker=71c1e68c-171a-4aa2-aca5-50ea153a3718");
 
@@ -400,6 +426,7 @@ public class SecurityGroupApiMockTest extends BaseNeutronApiMockTest {
    public void testListPagedSecurityGroupRulesFail() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404)));
 
       try {
@@ -412,8 +439,9 @@ public class SecurityGroupApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
-         assertEquals(server.getRequestCount(), 2);
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "GET", "/v2.0/security-group-rules");
 
          /*
@@ -430,6 +458,7 @@ public class SecurityGroupApiMockTest extends BaseNeutronApiMockTest {
    public void testGetSecurityGroup() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(
             new MockResponse().setResponseCode(201).setBody(stringFromResource("/security_group_get_response.json"))));
 
@@ -442,7 +471,9 @@ public class SecurityGroupApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "GET", "/v2.0/security-groups/12345");
 
          /*
@@ -463,6 +494,7 @@ public class SecurityGroupApiMockTest extends BaseNeutronApiMockTest {
    public void testGetSecurityGroupFail() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(
             new MockResponse().setResponseCode(404)));
 
@@ -475,7 +507,9 @@ public class SecurityGroupApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "GET", "/v2.0/security-groups/12345");
 
          /*
@@ -491,6 +525,7 @@ public class SecurityGroupApiMockTest extends BaseNeutronApiMockTest {
    public void testGetSecurityGroupRule() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(
             new MockResponse().setResponseCode(201).setBody(stringFromResource("/security_group_rule_get_response.json"))));
 
@@ -503,7 +538,9 @@ public class SecurityGroupApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "GET", "/v2.0/security-group-rules/12345");
 
          /*
@@ -524,6 +561,7 @@ public class SecurityGroupApiMockTest extends BaseNeutronApiMockTest {
    public void testGetSecurityGroupRuleFail() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(
             new MockResponse().setResponseCode(404)));
 
@@ -536,7 +574,9 @@ public class SecurityGroupApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "GET", "/v2.0/security-group-rules/12345");
 
          /*
@@ -552,6 +592,7 @@ public class SecurityGroupApiMockTest extends BaseNeutronApiMockTest {
    public void testDeleteSecurityGroup() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(
             new MockResponse().setResponseCode(201)));
 
@@ -564,7 +605,9 @@ public class SecurityGroupApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "DELETE", "/v2.0/security-groups/12345");
 
          /*
@@ -579,6 +622,7 @@ public class SecurityGroupApiMockTest extends BaseNeutronApiMockTest {
    public void testDeleteSecurityGroupFail() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(
             new MockResponse().setResponseCode(404)));
 
@@ -591,7 +635,9 @@ public class SecurityGroupApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "DELETE", "/v2.0/security-groups/12345");
 
          /*
@@ -606,6 +652,7 @@ public class SecurityGroupApiMockTest extends BaseNeutronApiMockTest {
    public void testDeleteSecurityGroupRule() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(
             new MockResponse().setResponseCode(201)));
 
@@ -618,7 +665,9 @@ public class SecurityGroupApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "DELETE", "/v2.0/security-group-rules/12345");
 
          /*
@@ -633,6 +682,7 @@ public class SecurityGroupApiMockTest extends BaseNeutronApiMockTest {
    public void testDeleteSecurityGroupRuleFail() throws IOException, InterruptedException, URISyntaxException {
       MockWebServer server = mockOpenStackServer();
       server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/access.json"))));
+      server.enqueue(addCommonHeaders(new MockResponse().setBody(stringFromResource("/extension_list.json"))));
       server.enqueue(addCommonHeaders(
             new MockResponse().setResponseCode(404)));
 
@@ -645,7 +695,9 @@ public class SecurityGroupApiMockTest extends BaseNeutronApiMockTest {
          /*
           * Check request
           */
+         assertEquals(server.getRequestCount(), 3);
          assertAuthentication(server);
+         assertExtensions(server, "/v2.0");
          assertRequest(server.takeRequest(), "DELETE", "/v2.0/security-group-rules/12345");
 
          /*


### PR DESCRIPTION
This PR annotates the Neutron APIs with `@Extension`, adds the `ExtensionNamespaces` class, and updates all mock tests. This aligns with the other OpenStack APIs and is related to [JCLOUDS-560](https://issues.apache.org/jira/browse/JCLOUDS-560)
