### PR TITLE
Remove unnecessary blobstore references

### DIFF
--- a/openstack-glance/src/test/resources/logback.xml
+++ b/openstack-glance/src/test/resources/logback.xml
@@ -34,14 +34,6 @@
         </encoder>
     </appender>
 
-    <appender name="BLOBSTOREFILE" class="ch.qos.logback.core.FileAppender">
-        <file>target/test-data/jclouds-blobstore.log</file>
-
-        <encoder>
-            <Pattern>%d %-5p [%c] [%thread] %m%n</Pattern>
-        </encoder>
-    </appender>
-    
     <root>
         <level value="warn" />
     </root>
@@ -59,11 +51,6 @@
     <logger name="jclouds.headers">
         <level value="DEBUG" />
         <appender-ref ref="WIREFILE" />
-    </logger>
-
-    <logger name="jclouds.blobstore">
-        <level value="DEBUG" />
-        <appender-ref ref="BLOBSTOREFILE" />
     </logger>
 
 </configuration>

--- a/openstack-marconi/pom.xml
+++ b/openstack-marconi/pom.xml
@@ -125,8 +125,6 @@
                     <test.openstack-marconi.identity>${test.openstack-marconi.identity}</test.openstack-marconi.identity>
                     <test.openstack-marconi.credential>${test.openstack-marconi.credential}</test.openstack-marconi.credential>
                     <test.jclouds.keystone.credential-type>${test.jclouds.keystone.credential-type}</test.jclouds.keystone.credential-type>
-                    <jclouds.blobstore.httpstream.url>${jclouds.blobstore.httpstream.url}</jclouds.blobstore.httpstream.url>
-                    <jclouds.blobstore.httpstream.md5>${jclouds.blobstore.httpstream.md5}</jclouds.blobstore.httpstream.md5>
                   </systemPropertyVariables>
                 </configuration>
               </execution>

--- a/openstack-marconi/src/test/resources/logback.xml
+++ b/openstack-marconi/src/test/resources/logback.xml
@@ -34,14 +34,6 @@
         </encoder>
     </appender>
 
-    <appender name="BLOBSTOREFILE" class="ch.qos.logback.core.FileAppender">
-        <file>target/test-data/jclouds-blobstore.log</file>
-
-        <encoder>
-            <Pattern>%d %-5p [%c] [%thread] %m%n</Pattern>
-        </encoder>
-    </appender>
-    
     <root>
         <level value="warn" />
     </root>
@@ -61,11 +53,6 @@
     <logger name="jclouds.headers">
         <level value="DEBUG" />
         <appender-ref ref="WIREFILE" />
-    </logger>
-
-    <logger name="jclouds.blobstore">
-        <level value="DEBUG" />
-        <appender-ref ref="BLOBSTOREFILE" />
     </logger>
 
 </configuration>

--- a/openstack-neutron/src/test/resources/logback.xml
+++ b/openstack-neutron/src/test/resources/logback.xml
@@ -34,14 +34,6 @@
         </encoder>
     </appender>
 
-    <appender name="BLOBSTOREFILE" class="ch.qos.logback.core.FileAppender">
-        <file>target/test-data/jclouds-blobstore.log</file>
-
-        <encoder>
-            <Pattern>%d %-5p [%c] [%thread] %m%n</Pattern>
-        </encoder>
-    </appender>
-
     <root>
         <level value="warn" />
     </root>
@@ -59,11 +51,6 @@
     <logger name="jclouds.headers">
         <level value="DEBUG" />
         <appender-ref ref="WIREFILE" />
-    </logger>
-
-    <logger name="jclouds.blobstore">
-        <level value="DEBUG" />
-        <appender-ref ref="BLOBSTOREFILE" />
     </logger>
 
 </configuration>

--- a/rackspace-autoscale-uk/src/test/resources/logback.xml
+++ b/rackspace-autoscale-uk/src/test/resources/logback.xml
@@ -34,14 +34,6 @@
         </encoder>
     </appender>
 
-    <appender name="BLOBSTOREFILE" class="ch.qos.logback.core.FileAppender">
-        <file>target/test-data/jclouds-blobstore.log</file>
-
-        <encoder>
-            <Pattern>%d %-5p [%c] [%thread] %m%n</Pattern>
-        </encoder>
-    </appender>
-
     <root>
         <level value="warn" />
     </root>
@@ -59,11 +51,6 @@
     <logger name="jclouds.headers">
         <level value="DEBUG" />
         <appender-ref ref="WIREFILE" />
-    </logger>
-
-    <logger name="jclouds.blobstore">
-        <level value="DEBUG" />
-        <appender-ref ref="BLOBSTOREFILE" />
     </logger>
 
 </configuration>

--- a/rackspace-autoscale-us/src/test/resources/logback.xml
+++ b/rackspace-autoscale-us/src/test/resources/logback.xml
@@ -34,14 +34,6 @@
         </encoder>
     </appender>
 
-    <appender name="BLOBSTOREFILE" class="ch.qos.logback.core.FileAppender">
-        <file>target/test-data/jclouds-blobstore.log</file>
-
-        <encoder>
-            <Pattern>%d %-5p [%c] [%thread] %m%n</Pattern>
-        </encoder>
-    </appender>
-
     <root>
         <level value="warn" />
     </root>
@@ -59,11 +51,6 @@
     <logger name="jclouds.headers">
         <level value="DEBUG" />
         <appender-ref ref="WIREFILE" />
-    </logger>
-
-    <logger name="jclouds.blobstore">
-        <level value="DEBUG" />
-        <appender-ref ref="BLOBSTOREFILE" />
     </logger>
 
 </configuration>

--- a/rackspace-cloudbigdata-us/src/test/resources/logback.xml
+++ b/rackspace-cloudbigdata-us/src/test/resources/logback.xml
@@ -34,14 +34,6 @@
         </encoder>
     </appender>
 
-    <appender name="BLOBSTOREFILE" class="ch.qos.logback.core.FileAppender">
-        <file>target/test-data/jclouds-blobstore.log</file>
-
-        <encoder>
-            <Pattern>%d %-5p [%c] [%thread] %m%n</Pattern>
-        </encoder>
-    </appender>
-
     <root>
         <level value="warn" />
     </root>
@@ -59,11 +51,6 @@
     <logger name="jclouds.headers">
         <level value="DEBUG" />
         <appender-ref ref="WIREFILE" />
-    </logger>
-
-    <logger name="jclouds.blobstore">
-        <level value="DEBUG" />
-        <appender-ref ref="BLOBSTOREFILE" />
     </logger>
 
 </configuration>

--- a/rackspace-cloudqueues-uk/src/test/resources/logback.xml
+++ b/rackspace-cloudqueues-uk/src/test/resources/logback.xml
@@ -34,14 +34,6 @@
         </encoder>
     </appender>
 
-    <appender name="BLOBSTOREFILE" class="ch.qos.logback.core.FileAppender">
-        <file>target/test-data/jclouds-blobstore.log</file>
-
-        <encoder>
-            <Pattern>%d %-5p [%c] [%thread] %m%n</Pattern>
-        </encoder>
-    </appender>
-
     <root>
         <level value="warn" />
     </root>
@@ -59,11 +51,6 @@
     <logger name="jclouds.headers">
         <level value="DEBUG" />
         <appender-ref ref="WIREFILE" />
-    </logger>
-
-    <logger name="jclouds.blobstore">
-        <level value="DEBUG" />
-        <appender-ref ref="BLOBSTOREFILE" />
     </logger>
 
 </configuration>

--- a/rackspace-cloudqueues-us/src/test/resources/logback.xml
+++ b/rackspace-cloudqueues-us/src/test/resources/logback.xml
@@ -34,14 +34,6 @@
         </encoder>
     </appender>
 
-    <appender name="BLOBSTOREFILE" class="ch.qos.logback.core.FileAppender">
-        <file>target/test-data/jclouds-blobstore.log</file>
-
-        <encoder>
-            <Pattern>%d %-5p [%c] [%thread] %m%n</Pattern>
-        </encoder>
-    </appender>
-
     <root>
         <level value="warn" />
     </root>
@@ -59,11 +51,6 @@
     <logger name="jclouds.headers">
         <level value="DEBUG" />
         <appender-ref ref="WIREFILE" />
-    </logger>
-
-    <logger name="jclouds.blobstore">
-        <level value="DEBUG" />
-        <appender-ref ref="BLOBSTOREFILE" />
     </logger>
 
 </configuration>


### PR DESCRIPTION
This is a complementary cleanup PR to [jclouds 521](https://github.com/jclouds/jclouds/pull/521) to remove blobstore references that are not required.
