### PR TITLE
openstack glance added option copy from to create image

### DIFF
--- a/openstack-glance/src/main/java/org/jclouds/openstack/glance/v1_0/options/CreateImageOptions.java
+++ b/openstack-glance/src/main/java/org/jclouds/openstack/glance/v1_0/options/CreateImageOptions.java
@@ -20,8 +20,6 @@ import org.jclouds.openstack.glance.v1_0.domain.ContainerFormat;
 import org.jclouds.openstack.glance.v1_0.domain.DiskFormat;
 import org.jclouds.openstack.glance.v1_0.domain.StoreType;
 
-import static org.jclouds.openstack.glance.v1_0.options.ImageField.COPY_FROM;
-
 /**
  * 
  * <h2></h2>Usage</h2> The recommended way to instantiate a CreateImageOptions object is to statically import
@@ -39,6 +37,8 @@ import static org.jclouds.openstack.glance.v1_0.options.ImageField.COPY_FROM;
  */
 public class CreateImageOptions extends UpdateImageOptions {
 
+   public static final String COPY_FROM = "x-glance-api-copy-from";
+
    /**
     * When present, Glance will use the supplied identifier for the image instead of generating one. If the identifier
     * already exists in that Glance node, then a 409 Conflict will be returned by Glance. The value of the header must
@@ -50,10 +50,10 @@ public class CreateImageOptions extends UpdateImageOptions {
    }
 
    /**
-    * @param url the url of the image to be copied into openstack
+    * @param url the url of the image to be copied
     */
    public UpdateImageOptions copyFrom(String url) {
-      headers.put(COPY_FROM.asGlanceHeader(), url);
+      headers.put(COPY_FROM, url);
       return this;
    }
 

--- a/openstack-glance/src/main/java/org/jclouds/openstack/glance/v1_0/options/ImageField.java
+++ b/openstack-glance/src/main/java/org/jclouds/openstack/glance/v1_0/options/ImageField.java
@@ -22,10 +22,9 @@ package org.jclouds.openstack.glance.v1_0.options;
  */
 public enum ImageField {
    ID, NAME, CHECKSUM, MIN_DISK, MIN_RAM, IS_PUBLIC, PROTECTED, CREATED_AT, UPDATED_AT, DELETED_AT,
-   OWNER, LOCATION, COPY_FROM, STATUS, DISK_FORMAT, CONTAINER_FORMAT, SIZE, SIZE_MIN, SIZE_MAX, STORE, PROPERTY;
+   OWNER, LOCATION, STATUS, DISK_FORMAT, CONTAINER_FORMAT, SIZE, SIZE_MIN, SIZE_MAX, STORE, PROPERTY;
 
    public static final String HEADER_PREFIX = "X-Image-Meta-";
-   public static final String GLANCE_HEADER_PREFIX = "x-glance-api-";
 
    public String asParam() {
       return name().toLowerCase();
@@ -33,9 +32,5 @@ public enum ImageField {
 
    public String asHeader() {
       return HEADER_PREFIX + name().charAt(0) + name().substring(1).toLowerCase();
-   }
-
-   public String asGlanceHeader() {
-      return GLANCE_HEADER_PREFIX + name().charAt(0) + name().substring(1).toLowerCase();
    }
 }


### PR DESCRIPTION
openstack glance added option copy from to create image so that the payload doesn't go through jclouds client
