### PR TITLE
Updated CloudNetworks ServiceType

### DIFF
--- a/rackspace-cloudnetworks-us/src/main/java/org/jclouds/rackspace/cloudnetworks/us/CloudNetworksUSProviderMetadata.java
+++ b/rackspace-cloudnetworks-us/src/main/java/org/jclouds/rackspace/cloudnetworks/us/CloudNetworksUSProviderMetadata.java
@@ -28,6 +28,7 @@ import java.util.Properties;
 import org.jclouds.openstack.keystone.v2_0.config.KeystoneAuthenticationModule.RegionModule;
 import org.jclouds.openstack.neutron.v2.NeutronApiMetadata;
 import org.jclouds.openstack.neutron.v2.config.NeutronHttpApiModule;
+import org.jclouds.openstack.v2_0.ServiceType;
 import org.jclouds.providers.ProviderMetadata;
 import org.jclouds.providers.internal.BaseProviderMetadata;
 import org.jclouds.rackspace.cloudidentity.v2_0.config.CloudIdentityAuthenticationApiModule;
@@ -65,7 +66,7 @@ public class CloudNetworksUSProviderMetadata extends BaseProviderMetadata {
    public static Properties defaultProperties() {
       Properties properties = new Properties();
       properties.setProperty(CREDENTIAL_TYPE, CloudIdentityCredentialTypes.API_KEY_CREDENTIALS);
-      properties.setProperty(SERVICE_TYPE, "networks");
+      properties.setProperty(SERVICE_TYPE, ServiceType.NETWORK);
 
       properties.setProperty(PROPERTY_REGIONS, "ORD,DFW,IAD,SYD,HKG");
       properties.setProperty(PROPERTY_REGION + ".ORD." + ISO3166_CODES, "US-IL");


### PR DESCRIPTION
This PR updates the service type from "networks" to "network" to align with the standard OpenStack naming convention for Neutron.
