### PR TITLE
Add Rackspace CDN UK/US Providers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,8 @@
     <module>rackspace-cloudfiles-us</module>
     <module>rackspace-cloudnetworks-uk</module>
     <module>rackspace-cloudnetworks-us</module>
+    <module>rackspace-cdn-uk</module>
+    <module>rackspace-cdn-us</module>
   </modules>
 
   <profiles>

--- a/rackspace-cdn-uk/README.md
+++ b/rackspace-cdn-uk/README.md
@@ -1,0 +1,7 @@
+Rackspace CDN UK
+========================
+
+The Rackspace CDN Provider for the UK region.
+
+Production ready?
+No

--- a/rackspace-cdn-uk/pom.xml
+++ b/rackspace-cdn-uk/pom.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.jclouds</groupId>
+    <artifactId>jclouds-project</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+    <relativePath />
+  </parent>
+
+  <!-- TODO: when out of labs, switch to org.jclouds.provider -->
+  <groupId>org.apache.jclouds.labs</groupId>
+  <artifactId>rackspace-cdn-uk</artifactId>
+  <version>2.0.0-SNAPSHOT</version>
+  <name>jclouds Rackspace CDN UK provider</name>
+  <description>OpenStack Poppy implementation targeted to Rackspace CDN UK</description>
+  <packaging>bundle</packaging>
+
+  <properties>
+    <!-- identity endpoint -->
+    <test.rackspace-cdn-uk.endpoint>https://lon.identity.api.rackspacecloud.com/v2.0/</test.rackspace-cdn-uk.endpoint>
+    <test.rackspace-cdn-uk.api-version>1</test.rackspace-cdn-uk.api-version>
+    <test.rackspace-cdn-uk.build-version />
+    <test.rackspace-cdn-uk.identity>${test.rackspace-uk.identity}</test.rackspace-cdn-uk.identity>
+    <test.rackspace-cdn-uk.credential>${test.rackspace-uk.credential}</test.rackspace-cdn-uk.credential>
+    <jclouds.osgi.export>org.jclouds.rackspace.cdn.uk*;version="${project.version}"</jclouds.osgi.export>
+    <jclouds.osgi.import>org.jclouds*;version="${project.version}",*</jclouds.osgi.import>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.jclouds.labs</groupId>
+      <artifactId>openstack-poppy</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.api</groupId>
+      <artifactId>rackspace-cloudidentity</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
+
+    <!-- Test Dependencies -->
+    <dependency>
+      <groupId>org.apache.jclouds.labs</groupId>
+      <artifactId>openstack-poppy</artifactId>
+      <version>${project.parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds</groupId>
+      <artifactId>jclouds-core</artifactId>
+      <version>${project.parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.driver</groupId>
+      <artifactId>jclouds-slf4j</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auto.service</groupId>
+      <artifactId>auto-service</artifactId>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+
+  <profiles>
+    <profile>
+      <id>live</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>integration</id>
+                <phase>integration-test</phase>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <systemPropertyVariables>
+                    <test.rackspace-cdn-uk.endpoint>${test.rackspace-cdn-uk.endpoint}</test.rackspace-cdn-uk.endpoint>
+                    <test.rackspace-cdn-uk.api-version>${test.rackspace-cdn-uk.api-version}</test.rackspace-cdn-uk.api-version>
+                    <test.rackspace-cdn-uk.build-version>${test.rackspace-cdn-uk.build-version}</test.rackspace-cdn-uk.build-version>
+                    <test.rackspace-cdn-uk.identity>${test.rackspace-cdn-uk.identity}</test.rackspace-cdn-uk.identity>
+                    <test.rackspace-cdn-uk.credential>${test.rackspace-cdn-uk.credential}</test.rackspace-cdn-uk.credential>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+</project>

--- a/rackspace-cdn-uk/src/main/java/org/jclouds/rackspace/cdn/uk/CDNUKProviderMetadata.java
+++ b/rackspace-cdn-uk/src/main/java/org/jclouds/rackspace/cdn/uk/CDNUKProviderMetadata.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cdn.uk;
+
+import static org.jclouds.location.reference.LocationConstants.ISO3166_CODES;
+import static org.jclouds.location.reference.LocationConstants.PROPERTY_REGION;
+import static org.jclouds.location.reference.LocationConstants.PROPERTY_REGIONS;
+import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.CREDENTIAL_TYPE;
+import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.SERVICE_TYPE;
+
+import java.net.URI;
+import java.util.Properties;
+
+import org.jclouds.openstack.keystone.v2_0.config.KeystoneAuthenticationModule.ProviderModule;
+import org.jclouds.openstack.poppy.v1.PoppyApiMetadata;
+import org.jclouds.openstack.poppy.v1.config.PoppyHttpApiModule;
+import org.jclouds.providers.ProviderMetadata;
+import org.jclouds.providers.internal.BaseProviderMetadata;
+import org.jclouds.rackspace.cloudidentity.v2_0.ServiceType;
+import org.jclouds.rackspace.cloudidentity.v2_0.config.CloudIdentityAuthenticationApiModule;
+import org.jclouds.rackspace.cloudidentity.v2_0.config.CloudIdentityAuthenticationModule;
+import org.jclouds.rackspace.cloudidentity.v2_0.config.CloudIdentityCredentialTypes;
+
+import com.google.auto.service.AutoService;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Module;
+
+@AutoService(ProviderMetadata.class)
+public class CDNUKProviderMetadata extends BaseProviderMetadata {
+
+   public static Builder builder() {
+      return new Builder();
+   }
+
+   @Override
+   public Builder toBuilder() {
+      return builder().fromProviderMetadata(this);
+   }
+
+   public CDNUKProviderMetadata() {
+      this(new Builder());
+   }
+
+   protected CDNUKProviderMetadata(Builder builder) {
+      super(builder);
+   }
+
+   /**
+    * @return a {@link Properties} object containing the default provider properties.
+    * This returns the credential type, service type, and configured regions.
+    */
+   public static Properties defaultProperties() {
+      Properties properties = new Properties();
+      properties.setProperty(CREDENTIAL_TYPE, CloudIdentityCredentialTypes.API_KEY_CREDENTIALS);
+      properties.setProperty(SERVICE_TYPE, ServiceType.CDN);
+
+      properties.setProperty(PROPERTY_REGIONS, "LON");
+      properties.setProperty(PROPERTY_REGION + ".LON." + ISO3166_CODES, "GB-SLG");
+
+      return properties;
+   }
+
+   public static class Builder extends BaseProviderMetadata.Builder {
+
+      protected Builder() {
+         id("rackspace-cdn-uk")
+         .name("Rackspace CDN UK")
+         .apiMetadata(new PoppyApiMetadata().toBuilder()
+               .identityName("${userName}")
+               .credentialName("${apiKey}")
+               .defaultEndpoint("https://lon.identity.api.rackspacecloud.com/v2.0/")
+               .documentation(URI.create("http://docs.rackspace.com/cdn/api/v1.0/cdn-devguide/content/index.html"))
+               .endpointName("Rackspace Cloud Identity service URL ending in /v2.0/")
+               .version("1")
+               .defaultModules(ImmutableSet.<Class<? extends Module>>builder()
+                     .add(CloudIdentityAuthenticationApiModule.class)
+                     .add(CloudIdentityAuthenticationModule.class)
+                     .add(ProviderModule.class)
+                     .add(PoppyHttpApiModule.class)
+                     .build())
+               .build())
+         .console(URI.create("https://mycloud.rackspace.co.uk"))
+         .linkedServices("rackspace-autoscale-uk", "rackspace-cloudblockstorage-uk", "rackspace-clouddatabases-uk",
+               "rackspace-clouddns-uk", "rackspace-cloudidentity", "rackspace-cloudloadbalancers-uk",
+               "rackspace-cloudqueues-uk", "rackspace-cloudservers-uk", "rackspace-cloudnetworks-uk")
+         .iso3166Codes("GB-SLG")
+         .defaultProperties(CDNUKProviderMetadata.defaultProperties());
+
+      }
+
+      @Override
+      public CDNUKProviderMetadata build() {
+         return new CDNUKProviderMetadata(this);
+      }
+
+      @Override
+      public Builder fromProviderMetadata(ProviderMetadata in) {
+         super.fromProviderMetadata(in);
+         return this;
+      }
+   }
+}

--- a/rackspace-cdn-uk/src/test/java/org/jclouds/rackspace/cdn/uk/CDNUKProviderTest.java
+++ b/rackspace-cdn-uk/src/test/java/org/jclouds/rackspace/cdn/uk/CDNUKProviderTest.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cdn.uk;
+
+import org.jclouds.openstack.poppy.v1.PoppyApiMetadata;
+import org.jclouds.providers.internal.BaseProviderMetadataTest;
+import org.testng.annotations.Test;
+
+@Test(groups = "unit", testName = "CDNUKProviderTest")
+public class CDNUKProviderTest extends BaseProviderMetadataTest {
+   public CDNUKProviderTest() {
+      super(new CDNUKProviderMetadata(), new PoppyApiMetadata());
+   }
+}

--- a/rackspace-cdn-uk/src/test/resources/logback.xml
+++ b/rackspace-cdn-uk/src/test/resources/logback.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration scan="false">
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>target/test-data/jclouds.log</file>
+
+        <encoder>
+            <Pattern>%d %-5p [%c] [%thread] %m%n</Pattern>
+        </encoder>
+    </appender>
+
+    <appender name="WIREFILE" class="ch.qos.logback.core.FileAppender">
+        <file>target/test-data/jclouds-wire.log</file>
+
+        <encoder>
+            <Pattern>%d %-5p [%c] [%thread] %m%n</Pattern>
+        </encoder>
+    </appender>
+
+    <root>
+        <level value="warn" />
+    </root>
+
+    <logger name="org.jclouds">
+        <level value="DEBUG" />
+        <appender-ref ref="FILE" />
+    </logger>
+
+    <logger name="jclouds.wire">
+        <level value="DEBUG" />
+        <appender-ref ref="WIREFILE" />
+    </logger>
+
+    <logger name="jclouds.headers">
+        <level value="DEBUG" />
+        <appender-ref ref="WIREFILE" />
+    </logger>
+
+</configuration>

--- a/rackspace-cdn-us/README.md
+++ b/rackspace-cdn-us/README.md
@@ -1,0 +1,7 @@
+Rackspace CDN US
+========================
+
+The Rackspace CDN Provider for the US region.
+
+Production ready?
+No

--- a/rackspace-cdn-us/pom.xml
+++ b/rackspace-cdn-us/pom.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.jclouds</groupId>
+    <artifactId>jclouds-project</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+    <relativePath />
+  </parent>
+
+  <!-- TODO: when out of labs, switch to org.jclouds.provider -->
+  <groupId>org.apache.jclouds.labs</groupId>
+  <artifactId>rackspace-cdn-us</artifactId>
+  <version>2.0.0-SNAPSHOT</version>
+  <name>jclouds Rackspace CDN US provider</name>
+  <description>OpenStack Poppy implementation targeted to Rackspace CDN US</description>
+  <packaging>bundle</packaging>
+
+  <properties>
+    <!-- identity endpoint -->
+    <test.rackspace-cdn-us.endpoint>https://identity.api.rackspacecloud.com/v2.0/</test.rackspace-cdn-us.endpoint>
+    <test.rackspace-cdn-us.api-version>1</test.rackspace-cdn-us.api-version>
+    <test.rackspace-cdn-us.build-version />
+    <test.rackspace-cdn-us.identity>${test.rackspace-us.identity}</test.rackspace-cdn-us.identity>
+    <test.rackspace-cdn-us.credential>${test.rackspace-us.credential}</test.rackspace-cdn-us.credential>
+    <jclouds.osgi.export>org.jclouds.rackspace.cdn.us*;version="${project.version}"</jclouds.osgi.export>
+    <jclouds.osgi.import>org.jclouds*;version="${project.version}",*</jclouds.osgi.import>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.jclouds.labs</groupId>
+      <artifactId>openstack-poppy</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.api</groupId>
+      <artifactId>rackspace-cloudidentity</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
+
+    <!-- Test Dependencies -->
+    <dependency>
+      <groupId>org.apache.jclouds.labs</groupId>
+      <artifactId>openstack-poppy</artifactId>
+      <version>${project.parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds</groupId>
+      <artifactId>jclouds-core</artifactId>
+      <version>${project.parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.driver</groupId>
+      <artifactId>jclouds-slf4j</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auto.service</groupId>
+      <artifactId>auto-service</artifactId>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+
+  <profiles>
+    <profile>
+      <id>live</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>integration</id>
+                <phase>integration-test</phase>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <systemPropertyVariables>
+                    <test.rackspace-cdn-us.endpoint>${test.rackspace-cdn-us.endpoint}</test.rackspace-cdn-us.endpoint>
+                    <test.rackspace-cdn-us.api-version>${test.rackspace-cdn-us.api-version}</test.rackspace-cdn-us.api-version>
+                    <test.rackspace-cdn-us.build-version>${test.rackspace-cdn-us.build-version}</test.rackspace-cdn-us.build-version>
+                    <test.rackspace-cdn-us.identity>${test.rackspace-cdn-us.identity}</test.rackspace-cdn-us.identity>
+                    <test.rackspace-cdn-us.credential>${test.rackspace-cdn-us.credential}</test.rackspace-cdn-us.credential>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+</project>

--- a/rackspace-cdn-us/src/main/java/org/jclouds/rackspace/cdn/us/CDNUSProviderMetadata.java
+++ b/rackspace-cdn-us/src/main/java/org/jclouds/rackspace/cdn/us/CDNUSProviderMetadata.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cdn.us;
+
+import static org.jclouds.location.reference.LocationConstants.ISO3166_CODES;
+import static org.jclouds.location.reference.LocationConstants.PROPERTY_REGION;
+import static org.jclouds.location.reference.LocationConstants.PROPERTY_REGIONS;
+import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.CREDENTIAL_TYPE;
+import static org.jclouds.openstack.keystone.v2_0.config.KeystoneProperties.SERVICE_TYPE;
+
+import java.net.URI;
+import java.util.Properties;
+
+import org.jclouds.openstack.keystone.v2_0.config.KeystoneAuthenticationModule.ProviderModule;
+import org.jclouds.openstack.poppy.v1.PoppyApiMetadata;
+import org.jclouds.openstack.poppy.v1.config.PoppyHttpApiModule;
+import org.jclouds.providers.ProviderMetadata;
+import org.jclouds.providers.internal.BaseProviderMetadata;
+import org.jclouds.rackspace.cloudidentity.v2_0.ServiceType;
+import org.jclouds.rackspace.cloudidentity.v2_0.config.CloudIdentityAuthenticationApiModule;
+import org.jclouds.rackspace.cloudidentity.v2_0.config.CloudIdentityAuthenticationModule;
+import org.jclouds.rackspace.cloudidentity.v2_0.config.CloudIdentityCredentialTypes;
+
+import com.google.auto.service.AutoService;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Module;
+
+@AutoService(ProviderMetadata.class)
+public class CDNUSProviderMetadata extends BaseProviderMetadata {
+
+   public static Builder builder() {
+      return new Builder();
+   }
+
+   @Override
+   public Builder toBuilder() {
+      return builder().fromProviderMetadata(this);
+   }
+
+   public CDNUSProviderMetadata() {
+      this(new Builder());
+   }
+
+   protected CDNUSProviderMetadata(Builder builder) {
+      super(builder);
+   }
+
+   /**
+    * @return a {@link Properties} object containing the default provider properties.
+    * This returns the credential type, service type, and configured regions.
+    */
+   public static Properties defaultProperties() {
+      Properties properties = new Properties();
+      properties.setProperty(CREDENTIAL_TYPE, CloudIdentityCredentialTypes.API_KEY_CREDENTIALS);
+      properties.setProperty(SERVICE_TYPE, ServiceType.CDN);
+
+      properties.setProperty(PROPERTY_REGIONS, "ORD,DFW,IAD,SYD,HKG");
+      properties.setProperty(PROPERTY_REGION + ".ORD." + ISO3166_CODES, "US-IL");
+      properties.setProperty(PROPERTY_REGION + ".DFW." + ISO3166_CODES, "US-TX");
+      properties.setProperty(PROPERTY_REGION + ".IAD." + ISO3166_CODES, "US-VA");
+      properties.setProperty(PROPERTY_REGION + ".SYD." + ISO3166_CODES, "AU-NSW");
+      properties.setProperty(PROPERTY_REGION + ".HKG." + ISO3166_CODES, "HK");
+
+      return properties;
+   }
+
+   public static class Builder extends BaseProviderMetadata.Builder {
+
+      protected Builder() {
+         id("rackspace-cdn-us")
+         .name("Rackspace CDN US")
+         .apiMetadata(new PoppyApiMetadata().toBuilder()
+               .identityName("${userName}")
+               .credentialName("${apiKey}")
+               .defaultEndpoint("https://identity.api.rackspacecloud.com/v2.0/")
+               .documentation(URI.create("http://docs.rackspace.com/cdn/api/v1.0/cdn-devguide/content/index.html"))
+               .endpointName("Rackspace Cloud Identity service URL ending in /v2.0/")
+               .version("1")
+               .defaultModules(ImmutableSet.<Class<? extends Module>>builder()
+                     .add(CloudIdentityAuthenticationApiModule.class)
+                     .add(CloudIdentityAuthenticationModule.class)
+                     .add(ProviderModule.class)
+                     .add(PoppyHttpApiModule.class)
+                     .build())
+               .build())
+         .homepage(URI.create("http://www.rackspace.com/cloud/cdn-content-delivery-network"))
+         .console(URI.create("https://mycloud.rackspace.com"))
+         .linkedServices("rackspace-autoscale-us", "rackspace-cloudblockstorage-us", "rackspace-clouddatabases-us",
+               "rackspace-clouddns-us", "rackspace-cloudidentity", "rackspace-cloudloadbalancers-us",
+               "rackspace-cloudqueues-us")
+         .iso3166Codes("US-IL", "US-TX", "US-VA", "AU-NSW", "HK")
+         .defaultProperties(CDNUSProviderMetadata.defaultProperties());
+
+      }
+
+      @Override
+      public CDNUSProviderMetadata build() {
+         return new CDNUSProviderMetadata(this);
+      }
+
+      @Override
+      public Builder fromProviderMetadata(ProviderMetadata in) {
+         super.fromProviderMetadata(in);
+         return this;
+      }
+   }
+}

--- a/rackspace-cdn-us/src/test/java/org/jclouds/rackspace/cdn/us/CDNUSProviderTest.java
+++ b/rackspace-cdn-us/src/test/java/org/jclouds/rackspace/cdn/us/CDNUSProviderTest.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.rackspace.cdn.us;
+
+import org.jclouds.openstack.poppy.v1.PoppyApiMetadata;
+import org.jclouds.providers.internal.BaseProviderMetadataTest;
+import org.testng.annotations.Test;
+
+@Test(groups = "unit", testName = "CDNUSProviderTest")
+public class CDNUSProviderTest extends BaseProviderMetadataTest {
+   public CDNUSProviderTest() {
+      super(new CDNUSProviderMetadata(), new PoppyApiMetadata());
+   }
+}

--- a/rackspace-cdn-us/src/test/resources/logback.xml
+++ b/rackspace-cdn-us/src/test/resources/logback.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration scan="false">
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>target/test-data/jclouds.log</file>
+
+        <encoder>
+            <Pattern>%d %-5p [%c] [%thread] %m%n</Pattern>
+        </encoder>
+    </appender>
+
+    <appender name="WIREFILE" class="ch.qos.logback.core.FileAppender">
+        <file>target/test-data/jclouds-wire.log</file>
+
+        <encoder>
+            <Pattern>%d %-5p [%c] [%thread] %m%n</Pattern>
+        </encoder>
+    </appender>
+
+    <root>
+        <level value="warn" />
+    </root>
+
+    <logger name="org.jclouds">
+        <level value="DEBUG" />
+        <appender-ref ref="FILE" />
+    </logger>
+
+    <logger name="jclouds.wire">
+        <level value="DEBUG" />
+        <appender-ref ref="WIREFILE" />
+    </logger>
+
+    <logger name="jclouds.headers">
+        <level value="DEBUG" />
+        <appender-ref ref="WIREFILE" />
+    </logger>
+
+</configuration>


### PR DESCRIPTION
This PR adds support for the Early Access Rackspace CDN US/UK Providers, which is based on the OpenStack Poppy API.