### PR TITLE
Adds more information about the neutron extensions.

### DIFF
--- a/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2/config/NeutronHttpApiModule.java
+++ b/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2/config/NeutronHttpApiModule.java
@@ -62,12 +62,12 @@ public class NeutronHttpApiModule extends HttpApiModule<NeutronApi> {
    }
 
    private void bindAliases() {
-      MapBinder<URI, URI> aliases = namespaceAliasBinder(binder());
-      aliases.addBinding(URI.create(ExtensionNamespaces.L3_ROUTER)).toInstance(
+      MapBinder<URI, URI> namespaceAliases = namespaceAliasBinder(binder());
+      namespaceAliases.addBinding(URI.create(ExtensionNamespaces.L3_ROUTER)).toInstance(
             URI.create("http://docs.openstack.org/ext/neutron/router/api/v1.0"));
-      aliases.addBinding(URI.create(ExtensionNamespaces.SECURITY_GROUPS)).toInstance(
+      namespaceAliases.addBinding(URI.create(ExtensionNamespaces.SECURITY_GROUPS)).toInstance(
             URI.create("http://docs.openstack.org/ext/securitygroups/api/v2.0"));
-      aliases.addBinding(URI.create(ExtensionNamespaces.LBAAS)).toInstance(
+      namespaceAliases.addBinding(URI.create(ExtensionNamespaces.LBAAS)).toInstance(
             URI.create("http://docs.openstack.org/networking/ext/lbaas/api/v1.0"));
    }
 

--- a/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2/extensions/FWaaSApi.java
+++ b/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2/extensions/FWaaSApi.java
@@ -67,12 +67,14 @@ import com.google.common.annotations.Beta;
  *
  * @see <a href=
  *      "http://specs.openstack.org/openstack/neutron-specs/specs/api/firewall_as_a_service__fwaas_.html">api doc</a>
+ * @see <a href=
+ *      "http://git.openstack.org/cgit/openstack/neutron-fwaas/tree/neutron_fwaas/extensions/firewall.py">extension info</a>
  */
 @Beta
 @Path("/fw")
 @RequestFilters(AuthenticateRequest.class)
 @Consumes(MediaType.APPLICATION_JSON)
-@Extension(of = ServiceType.NETWORK, namespace = ExtensionNamespaces.FWAAS)
+@Extension(of = ServiceType.NETWORK, namespace = ExtensionNamespaces.FWAAS, name = "Firewall service", alias = "fwaas")
 public interface FWaaSApi {
 
    /**

--- a/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2/extensions/FloatingIPApi.java
+++ b/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2/extensions/FloatingIPApi.java
@@ -61,7 +61,7 @@ import com.google.common.annotations.Beta;
 @Path("/floatingips")
 @RequestFilters(AuthenticateRequest.class)
 @Consumes(MediaType.APPLICATION_JSON)
-@Extension(of = ServiceType.NETWORK, namespace = ExtensionNamespaces.L3_ROUTER)
+@Extension(of = ServiceType.NETWORK, namespace = ExtensionNamespaces.L3_ROUTER, name = "Neutron L3 Router", alias = "router")
 public interface FloatingIPApi {
 
    /**

--- a/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2/extensions/RouterApi.java
+++ b/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2/extensions/RouterApi.java
@@ -61,12 +61,15 @@ import com.google.common.annotations.Beta;
  *
  * @see <a href=
  *      "http://docs.openstack.org/api/openstack-network/2.0/content/router_ext.html">api doc</a>
+ *
+ * @see <a href=
+ * "https://github.com/openstack/neutron/tree/master/neutron/extensions">neutron extensions</a>
  */
 @Beta
 @Path("/routers")
 @RequestFilters(AuthenticateRequest.class)
 @Consumes(MediaType.APPLICATION_JSON)
-@Extension(of = ServiceType.NETWORK, namespace = ExtensionNamespaces.L3_ROUTER)
+@Extension(of = ServiceType.NETWORK, namespace = ExtensionNamespaces.L3_ROUTER, name = "Neutron L3 Router", alias = "router")
 public interface RouterApi {
 
    /**

--- a/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2/extensions/SecurityGroupApi.java
+++ b/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2/extensions/SecurityGroupApi.java
@@ -64,7 +64,7 @@ import com.google.common.annotations.Beta;
 @RequestFilters(AuthenticateRequest.class)
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
-@Extension(of = ServiceType.NETWORK, namespace = ExtensionNamespaces.SECURITY_GROUPS)
+@Extension(of = ServiceType.NETWORK, namespace = ExtensionNamespaces.SECURITY_GROUPS, name = "security-group", alias = "security-group")
 public interface SecurityGroupApi {
    /**
     * Groups


### PR DESCRIPTION
Name can already be used for automatic resolution.

Needed because namespace is being deprecated. Alias should also be added at some point (for automatic resolution).