### PR TITLE
Replace ${project.version} by ${project.parent.version}

### DIFF
--- a/rackspace-cloudbigdata/pom.xml
+++ b/rackspace-cloudbigdata/pom.xml
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>org.apache.jclouds</groupId>
       <artifactId>jclouds-compute</artifactId>
-      <version>${project.version}</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.jclouds.api</groupId>


### PR DESCRIPTION
Even if usually the project and its parent have the same version, dependencies
are resolved using parent POM, so all internal dependencies should use the
parent version (that's the case for all other dependencies in the project).